### PR TITLE
STRIPESFF-28: Add stripes-final-form typings

### DIFF
--- a/final-form/index.d.ts
+++ b/final-form/index.d.ts
@@ -1,0 +1,2 @@
+// targeted to stripes-final-form v7.0.0
+export { default } from './lib/stripesFinalForm';

--- a/final-form/lib/stripesFinalForm.d.ts
+++ b/final-form/lib/stripesFinalForm.d.ts
@@ -1,0 +1,31 @@
+import { ComponentType } from 'react';
+import { FormProps, FormRenderProps } from 'react-final-form';
+
+/**
+ * these are put on the wrapper component rather than passed within `opts`
+ */
+type extractedProps = 'onSubmit' | 'initialValues';
+
+/**
+ * A `react-final-form` wrapper for Stripes.
+ *
+ * @param opts Options to be passed to `react-final-form`'s {@link FormProps}, such as `validate` or `validateOnBlur`
+ * @param Component the component to be wrapped; this will be passed the {@link FormRenderProps} such as `handleSubmit` and any other props passed to the wrapper component
+ * @param ComponentProps extra props which should be forwarded from the wrapper to the underlying form component
+ * @param FormValues the type of the form's values
+ *
+ * @example
+ * stripesFinalForm({
+ *   // options for react-final-form
+ * })(FormComponent)
+ */
+export default function stripesFinalForm<
+  ComponentProps = Record<string, unknown>,
+  FormValues = Record<string, unknown>
+>(
+  opts: Omit<FormProps<FormValues>, extractedProps> & {
+    navigationCheck?: boolean;
+  }
+): (
+  Component: ComponentType<FormRenderProps<FormValues> & ComponentProps>
+) => ComponentType<ComponentProps & Pick<FormProps<FormValues>, extractedProps>>;

--- a/package.json
+++ b/package.json
@@ -19,9 +19,11 @@
   },
   "dependencies": {
     "@folio/eslint-config-stripes": "^6.5.0",
-    "@types/react": "^17.0.2"
+    "@types/react": "^17.0.2",
+    "react-final-form": "^6.5.9"
   },
   "peerDependencies": {
+    "@types/react": "^17.0.2",
     "react": "^17.0.2"
   },
   "scripts": {


### PR DESCRIPTION
# [Jira STRIPESFF-28](https://issues.folio.org/browse/STRIPESFF-28)

This adds typings for `stripes-final-form` v7.0.0