### PR TITLE
Revert "Temporary sonar fix"

### DIFF
--- a/.github/workflows/build-npm-release.yml
+++ b/.github/workflows/build-npm-release.yml
@@ -197,7 +197,7 @@ jobs:
         with:
           args: >
             -Dsonar.organization=folio-org
-            -Dsonar.projectKey=folio-org_${{ github.event.repository.name }}
+            -Dsonar.projectKey=org.folio:${{ github.event.repository.name }}
             -Dsonar.projectName=${{ github.event.repository.name }}
             -Dsonar.sources=${{ env.SQ_ROOT_DIR }}
             -Dsonar.language=js

--- a/.github/workflows/build-npm.yml
+++ b/.github/workflows/build-npm.yml
@@ -138,7 +138,7 @@ jobs:
         with:
           args: >
             -Dsonar.organization=folio-org
-            -Dsonar.projectKey=folio-org_${{ github.event.repository.name }}
+            -Dsonar.projectKey=org.folio:${{ github.event.repository.name }}
             -Dsonar.projectName=${{ github.event.repository.name }}
             -Dsonar.sources=${{ env.SQ_ROOT_DIR }}
             -Dsonar.language=js


### PR DESCRIPTION
This reverts commit 7274c554463f6cc77a239dc4055bf9079fdc7d0f, now that sonar's bug is fixed and colons can be used in project names.