### PR TITLE
[STCOM-1152] Add assorted typings

### DIFF
--- a/components/index.d.ts
+++ b/components/index.d.ts
@@ -51,15 +51,24 @@ export { default as EndOfList } from './lib/MultiColumnList/EndOfList';
 export { default as List } from './lib/List';
 
 /* layout containers */
-export { default as Pane } from './lib/Pane';
-export { default as PaneHeaderIconButton } from './lib/PaneHeaderIconButton';
-export { default as PaneBackLink } from './lib/PaneBackLink';
-export { default as PaneCloseLink } from './lib/PaneCloseLink';
-export { default as PaneHeader } from './lib/PaneHeader';
-export { default as PaneFooter } from './lib/PaneFooter';
-export { default as PaneSubheader } from './lib/PaneSubheader';
-export { default as PaneMenu } from './lib/PaneMenu';
-export { default as Paneset } from './lib/Paneset';
+export { default as Pane, PaneProps } from './lib/Pane';
+export { default as PaneBackLink, PaneBackLinkProps } from './lib/PaneBackLink';
+export {
+  default as PaneCloseLink,
+  PaneCloseLinkProps,
+} from './lib/PaneCloseLink';
+export { default as PaneFooter, PaneFooterProps } from './lib/PaneFooter';
+export { default as PaneHeader, PaneHeaderProps } from './lib/PaneHeader';
+export {
+  default as PaneHeaderIconButton,
+  PaneHeaderIconButtonProps,
+} from './lib/PaneHeaderIconButton';
+export { default as PaneMenu, PaneMenuProps } from './lib/PaneMenu';
+export {
+  default as PaneSubheader,
+  PaneSubheaderProps,
+} from './lib/PaneSubheader';
+export { default as Paneset, PanesetProps } from './lib/Paneset';
 export { default as Layer } from './lib/Layer';
 export { Grid, Row, Col } from './lib/LayoutGrid';
 export { default as Layout } from './lib/Layout';

--- a/components/index.d.ts
+++ b/components/index.d.ts
@@ -8,6 +8,7 @@ export { default as CurrencySelect } from './lib/CurrencySelect';
 export { default as CountrySelection } from './lib/CountrySelection';
 export type {
   default as Datepicker,
+  DatepickerProps,
   Calendar,
   staticFirstWeekDay,
   staticLangCountryCodes,

--- a/components/index.d.ts
+++ b/components/index.d.ts
@@ -1,6 +1,6 @@
 /* form elements */
 export { default as AutoSuggest } from './lib/AutoSuggest';
-export { default as Badge } from './lib/Badge';
+export { default as Badge, BadgeProps } from './lib/Badge';
 export { default as Button, ButtonProps } from './lib/Button';
 export { default as ButtonGroup } from './lib/ButtonGroup';
 export { default as Checkbox } from './lib/Checkbox';

--- a/components/index.d.ts
+++ b/components/index.d.ts
@@ -83,7 +83,7 @@ export { default as Modal } from './lib/Modal';
 export { default as ModalFooter } from './lib/ModalFooter';
 export { default as Avatar } from './lib/Avatar';
 export { default as Callout, CalloutElement } from './lib/Callout';
-export { default as Dropdown } from './lib/Dropdown';
+export { default as Dropdown, DropdownProps } from './lib/Dropdown';
 export { default as DropdownMenu } from './lib/DropdownMenu';
 export { default as DropdownButton } from './lib/DropdownButton';
 export { default as MenuSection } from './lib/MenuSection';

--- a/components/index.d.ts
+++ b/components/index.d.ts
@@ -30,7 +30,7 @@ export { default as Select } from './lib/Select';
 export { default as Spinner } from './lib/Spinner';
 export { default as TextArea } from './lib/TextArea';
 export { default as TextField } from './lib/TextField';
-export { default as Timepicker } from './lib/Timepicker';
+export { default as Timepicker, TimepickerProps } from './lib/Timepicker';
 export { default as Tooltip } from './lib/Tooltip';
 export { default as Editor } from './lib/Editor';
 export { default as MultiSelection } from './lib/MultiSelection';

--- a/components/index.d.ts
+++ b/components/index.d.ts
@@ -12,7 +12,10 @@ export type {
   staticFirstWeekDay,
   staticLangCountryCodes,
 } from './lib/Datepicker';
-export { getLocaleDateFormat, getLocalizedTimeFormatInfo } from './util/dateTimeUtils';
+export {
+  getLocaleDateFormat,
+  getLocalizedTimeFormatInfo,
+} from './util/dateTimeUtils';
 export { default as DateRangeWrapper } from './lib/DateRangeWrapper';
 export { default as FormattedDate } from './lib/FormattedDate';
 export { default as FormattedTime } from './lib/FormattedTime';
@@ -38,7 +41,12 @@ export { default as Popper, AVAILABLE_PLACEMENTS } from './lib/Popper';
 export { default as Card } from './lib/Card';
 export { default as KeyboardShortcutsModal } from './lib/KeyboardShortcutsModal';
 export { default as KeyValue } from './lib/KeyValue';
-export { default as MultiColumnList, DefaultMCLRowFormatter } from './lib/MultiColumnList';
+export {
+  default as MultiColumnList,
+  DefaultMCLRowFormatter,
+  MultiColumnListRowFormatterProps,
+  MultiColumnListProps,
+} from './lib/MultiColumnList';
 export { default as EndOfList } from './lib/MultiColumnList/EndOfList';
 export { default as List } from './lib/List';
 
@@ -154,9 +162,17 @@ export {
   currenciesOptions,
 } from './util/currencies';
 
-export { default as countries, countriesByCode, countryCodes } from './util/countries';
+export {
+  default as countries,
+  countriesByCode,
+  countryCodes,
+} from './util/countries';
 
-export { formattedLanguageName, languageOptions, default as languages } from './util/languages';
+export {
+  formattedLanguageName,
+  languageOptions,
+  default as languages,
+} from './util/languages';
 
 export { default as nativeChangeFieldValue } from './util/nativeChangeFieldValue';
 

--- a/components/index.d.ts
+++ b/components/index.d.ts
@@ -87,7 +87,7 @@ export {
 
 /* misc */
 export { default as Icon } from './lib/Icon';
-export { default as IconButton } from './lib/IconButton';
+export { default as IconButton, IconButtonProps } from './lib/IconButton';
 export { default as MessageBanner } from './lib/MessageBanner';
 export { default as Modal } from './lib/Modal';
 export { default as ModalFooter } from './lib/ModalFooter';

--- a/components/index.d.ts
+++ b/components/index.d.ts
@@ -1,7 +1,7 @@
 /* form elements */
 export { default as AutoSuggest } from './lib/AutoSuggest';
 export { default as Badge } from './lib/Badge';
-export { default as Button } from './lib/Button';
+export { default as Button, ButtonProps } from './lib/Button';
 export { default as ButtonGroup } from './lib/ButtonGroup';
 export { default as Checkbox } from './lib/Checkbox';
 export { default as CurrencySelect } from './lib/CurrencySelect';

--- a/components/lib/Badge/Badge.d.ts
+++ b/components/lib/Badge/Badge.d.ts
@@ -1,0 +1,20 @@
+import { FunctionComponent, ReactNode } from 'react';
+
+export interface BadgeProps {
+  /** What should be displayed in the badge */
+  children: ReactNode;
+  /** Adds a custom class to the badge */
+  className?: string;
+  /** Sets the color of the badge */
+  color?: 'default' | 'primary' | 'red';
+  /** The size of the badge */
+  size?: 'small' | 'medium';
+}
+
+/**
+ * Renders a badge for showing notifications, etc
+ * @example
+ * <Badge color="red">3</Badge>
+ */
+declare const Badge: FunctionComponent<BadgeProps>;
+export default Badge;

--- a/components/lib/Badge/index.d.ts
+++ b/components/lib/Badge/index.d.ts
@@ -1,2 +1,1 @@
-declare const Badge: any;
-export default Badge;
+export { default, BadgeProps } from './Badge';

--- a/components/lib/Button/Button.d.ts
+++ b/components/lib/Button/Button.d.ts
@@ -1,0 +1,67 @@
+import {
+  AriaAttributes,
+  ForwardRefExoticComponent,
+  MouseEventHandler,
+  PropsWithoutRef,
+  ReactNode,
+  RefAttributes,
+} from 'react';
+import { LinkProps } from 'react-router-dom';
+
+export interface ButtonBaseProps extends AriaAttributes {
+  /** Changes the (flex box) alignment of the button */
+  align?: 'start' | 'center' | 'end';
+  /** Allows the anchor's default onClick */
+  allowAnchorClick?: boolean;
+  /** If this button should be automatically focused */
+  autoFocus?: boolean;
+  /** Remove the margin from the bottom */
+  bottomMargin0?: boolean;
+  /** Add a custom CSS class to the button */
+  buttonClass?: string;
+  /** Sets the style of the button */
+  buttonStyle?:
+    | 'default'
+    | 'primary'
+    | 'success'
+    | 'warning'
+    | 'danger'
+    | 'dropdownItem';
+  /** The button for the label */
+  children: ReactNode;
+  /** Forces the button to 100% width */
+  fullWidth?: boolean;
+  /** Remove the margin from the bottom */
+  marginBottom0?: boolean;
+  /** Handle an `onClick` event */
+  onClick?: MouseEventHandler<HTMLAnchorElement | HTMLButtonElement>;
+  /** Remove the padding from all sides */
+  paddingSide0?: boolean;
+  /** Adds a custom role to the button */
+  role?: JSX.IntrinsicElements['button']['role'];
+
+  /** Set the type of `<button>`.  Incompatible with `href` and `to` */
+  type?: JSX.IntrinsicElements['button']['type'];
+  /** Adds a link to the button, like a normal <a>.  Incompatible with `type` and `to`. */
+  href?: string;
+  /**
+   * Controls where the link should go, like for a `<Link>`.
+   * This prop is incompatible with `type` and `href`.
+   * @see https://github.com/remix-run/react-router/blob/master/docs/components/link.md
+   */
+  to?: LinkProps['to'];
+}
+
+export type ButtonProps = ButtonBaseProps &
+  (JSX.IntrinsicElements['button'] | JSX.IntrinsicElements['a']);
+
+/**
+ * Renders a given button
+ * @example
+ * <Button>Sample</Button>
+ */
+export const Button: ForwardRefExoticComponent<
+  PropsWithoutRef<ButtonProps> &
+    RefAttributes<HTMLAnchorElement | HTMLButtonElement>
+>;
+export default Button;

--- a/components/lib/Button/index.d.ts
+++ b/components/lib/Button/index.d.ts
@@ -1,2 +1,1 @@
-declare const Button: any;
-export default Button;
+export { default, ButtonProps } from './Button';

--- a/components/lib/Datepicker/Datepicker.d.ts
+++ b/components/lib/Datepicker/Datepicker.d.ts
@@ -1,0 +1,100 @@
+import { Moment } from 'moment';
+import Popper from 'popper.js';
+import {
+  AriaAttributes,
+  Component,
+  FocusEventHandler,
+  ReactNode,
+  RefObject,
+} from 'react';
+import { FieldRenderProps } from 'react-final-form';
+
+export interface DatepickerBaseProps
+  extends AriaAttributes,
+    FieldRenderProps<string> {
+  /** If the field should auto-focus on mount */
+  autoFocus?: boolean;
+  /** How backend dates should be parsed, e.g. `"ISO 8601"` */
+  backendDateStandard?: string;
+  /** How the date should be formatted/localized, e.g. `YYYY.MM.DD` */
+  dateFormat?: string;
+  /** Disables the input field */
+  disabled?: boolean;
+  /** Disallows selection of dates that the function returns true */
+  exclude?: (moment: Moment) => boolean;
+  /** If the picker should close once a date is clicked */
+  hideOnChoose?: boolean;
+  /** Adds a custom ID to the control */
+  id?: string;
+  /** Ref to the internal text field */
+  inputRef?: RefObject<HTMLInputElement> | ((el: HTMLInputElement) => void);
+  /** Label the datepicker */
+  label?: ReactNode;
+  /** Set the locale for use */
+  locale?: string;
+  /** Remove bottom margin */
+  marginBottom0?: boolean;
+  /** Popper modifiers */
+  modifiers?: Popper.Modifiers;
+  /** Fired when the user clicks out of/deselects the control */
+  onBlur?: FocusEventHandler;
+  /** Fired anytime internal state changes */
+  onChange?: (e: Event, formatted: string, dateString: string) => void;
+  /** Fired when the user clicks into the control */
+  onFocus?: FocusEventHandler;
+  /** When a date is chosen on the calendar */
+  onSetDate?: (date: Moment) => void;
+  /** Parses a date for local display in the text field */
+  parser?: (value: string) => string;
+  /** Where the overlay should be placed in relation to the field */
+  placement?: Popper.Placement;
+  /** If the control is readonly */
+  readOnly?: boolean;
+  /** If the field is required */
+  required?: boolean;
+  /** Additional message to be read when the field is focused */
+  screenReaderMessage?: boolean;
+  /** If the calendar should start off opened */
+  showCalendar?: boolean;
+  /** Override the default timezone */
+  timeZone?: string;
+  /** If focusing the text field should open the calendar popup */
+  useFocus?: boolean;
+  /** If the field is being used within a final-form or similar */
+  useInput?: boolean;
+  /** Render to the global overlay, if the dropdown may be cut off due to some containing elements's overflow */
+  usePortal?: boolean;
+  /** The field's value */
+  value?: string;
+}
+
+export type DatepickerOutputProps =
+  | {
+      // /** Determines if the datepicker's value will be the formatted local string or one ready for the backend */
+      outputBackendValue?: false;
+      outputFormatter?: never;
+    }
+  | {
+      // /** Determines if the datepicker's value will be the formatted local string or one ready for the backend */
+      outputBackendValue: true;
+      // /** Formats a date for the backend */
+      outputFormatter?: (date: Moment) => string;
+    };
+
+// only allow `outputFormatter` if `outputBackendValue` is true
+export type DatepickerProps = DatepickerBaseProps & DatepickerOutputProps;
+
+/**
+ * A picker for dates with an optional calendar popup
+ * @example
+ * <Datepicker />
+ * // or pass as component within a form...
+ * <Field component={Datepicker} />
+ * @example
+ * <Datepicker
+ *   label="Date"
+ *   value={this.state.day1}
+ *   onChange={handleDateChange}
+ * />
+ */
+export default class Datepicker extends Component<DatepickerProps> {}

--- a/components/lib/Datepicker/index.d.ts
+++ b/components/lib/Datepicker/index.d.ts
@@ -1,6 +1,6 @@
-export const Calendar: any;
-export const staticFirstWeekDay: any;
-export const staticLangCountryCodes: any;
+export { default, DatepickerProps } from './Datepicker';
+export { default as staticFirstWeekDay } from './staticFirstWeekDay';
+export { default as staticLangCountryCodes } from './staticLangCountryCodes';
 
-declare const Datepicker: any;
-export default Datepicker;
+// TODO
+export const Calendar: any;

--- a/components/lib/Datepicker/staticFirstWeekDay.d.ts
+++ b/components/lib/Datepicker/staticFirstWeekDay.d.ts
@@ -1,0 +1,6 @@
+declare const data: Record<
+  'sat' | 'sun' | 'mon' | 'tue' | 'wed' | 'thu' | 'fri',
+  string[]
+>;
+
+export default data;

--- a/components/lib/Datepicker/staticLangCountryCodes.d.ts
+++ b/components/lib/Datepicker/staticLangCountryCodes.d.ts
@@ -1,0 +1,3 @@
+declare const data: Record<string, string>;
+
+export default data;

--- a/components/lib/Dropdown/Dropdown.d.ts
+++ b/components/lib/Dropdown/Dropdown.d.ts
@@ -1,5 +1,5 @@
 import Popper from 'popper.js';
-import React, {
+import {
   AriaAttributes,
   Component,
   ElementType,

--- a/components/lib/Dropdown/Dropdown.d.ts
+++ b/components/lib/Dropdown/Dropdown.d.ts
@@ -1,0 +1,160 @@
+import Popper from 'popper.js';
+import React, {
+  AriaAttributes,
+  Component,
+  ElementType,
+  FocusEventHandler,
+  KeyboardEventHandler,
+  ReactNode,
+  RefObject,
+} from 'react';
+import { RequireAllOrNone } from 'type-fest';
+import { ButtonProps } from '../Button/Button';
+
+export interface DropdownBaseProps extends AriaAttributes {
+  /** Adds additional classes to the wrapping element */
+  className?: string;
+  /** If the dropdown should be disabled/inactive */
+  disabled?: boolean;
+  /** Custom handlers for when the dropdown is opened or closed */
+  focusHandlers?: {
+    open?: (
+      trigger?: React.RefObject<HTMLElement>,
+      menu?: HTMLElement,
+      firstItem?: HTMLElement
+    ) => void;
+    close?: (
+      trigger?: React.RefObject<HTMLElement>,
+      menu?: HTMLElement
+    ) => void;
+  };
+  /** Overrides the ID for the dropdown */
+  id?: string;
+  /** Controls the addition of padding within the dropdown */
+  hasPadding?: boolean;
+  /** Custom modifiers for how the popper should render */
+  modifiers?: Popper.Modifiers;
+  /** Custom placement for the popper */
+  placement?: Popper.Placement;
+  /** If `position: relative` should be applied */
+  relativePosition?: boolean;
+  /** A custom tag for the main wrapping element */
+  tag?: ElementType;
+  /** If the dropdown should be rendered to overall `#OverlayContainer` div */
+  usePortal?: boolean;
+}
+
+export interface DropdownTriggerBuiltinProps {
+  /** Additional props to add to the builtin button trigger */
+  buttonProps?: Partial<ButtonProps>;
+  /** The label for the button trigger */
+  label: ReactNode;
+}
+
+export interface DropdownTriggerCustomProps {
+  /** A custom function to render the trigger */
+  renderTrigger: (props: {
+    getTriggerProps: (opts: {
+      onFocus?: FocusEventHandler;
+      onBlur?: FocusEventHandler;
+    }) => void;
+    open: boolean;
+    triggerRef: RefObject<Element>;
+    onToggle: (e: Event) => void;
+    ariaProps: Partial<AriaAttributes>;
+    keyHandler: KeyboardEventHandler;
+    buttonProps: Partial<ButtonProps>;
+    label: string;
+  }) => ReactNode;
+}
+
+export interface DropdownMenuFunction {
+  (props: {
+    open: boolean;
+    onToggle: () => void;
+    keyHandler?: KeyboardEventHandler;
+  }): ReactNode;
+}
+
+export interface DropdownMenuChildrenProps {
+  /**
+   * The dropdown's menu/contents, as children.
+   * A custom function may also be passed here
+   */
+  children: ReactNode | DropdownMenuFunction;
+}
+
+export interface DropdownMenuPropFunctionProps {
+  /** A custom function to render the menu/contents of the dropdown  */
+  renderMenu: DropdownMenuFunction;
+}
+
+export interface DropdownControlledProps {
+  /**
+   * A function to be called when the dropdown should be toggled
+   * (e.g. from the Escape key or a click outside the popper)
+   */
+  onToggle: () => void;
+  /** If the dropdown should currently be open */
+  open: boolean;
+}
+
+export type DropdownProps = DropdownBaseProps &
+  (DropdownTriggerBuiltinProps | DropdownTriggerCustomProps) &
+  (DropdownMenuChildrenProps | DropdownMenuPropFunctionProps) &
+  RequireAllOrNone<DropdownControlledProps, 'onToggle' | 'open'>;
+
+/**
+ * Renders a dropdown for displaying links of lists and more
+ * @example
+ * The most straightforward use will cause the component to render its own
+ * control button and handle its own state:
+ * ```
+ * <Dropdown label="Dropdown Example">
+ *   <DropdownMenu>
+ *     <ul>
+ *       <li><a href="#">Example Link 1</a></li>
+ *       <li><a href="#">Example Link 2</a></li>
+ *     </ul>
+ *   </DropdownMenu>
+ * </Dropdown>
+ * ```
+ * @example
+ * If more control is needed, state can be managed externally via `onToggle`
+ * and `open` props.  Additionally, `renderMenu` and `renderTrigger` props
+ * allow custom render functions which will receive status information,
+ * handlers, and more:
+ * ```
+ * const trigger = ({ triggerRef, toggleMenu, ariaProps, keyHandler }) => (
+ *   <Button autoFocus ref={triggerRef} onClick={toggleMenu} onKeyDown={keyHandler} {...ariaProps}>
+ *     Trigger
+ *   </Button>
+ * );
+ *
+ * const menu = ({open, onToggle, keyHandler}) => {
+ *   <DropdownMenu
+ *     role="menu"
+ *     aria-label="available permissions"
+ *     onToggle={this.onToggleAddPermDD}
+ *   >
+ *     <Button
+ *       buttonStyle="menuItem"
+ *       role="menuitem"
+ *       onClick={ () => {this.selectMethod(onToggle)}}
+ *     >
+ *       Select All
+ *     </Button>
+ *   </DropdownMenu>
+ * }
+ *
+ * <Dropdown
+ *   id="AddPermissionDropdown"
+ *   renderTrigger={this.trigger}
+ *   renderMenu={this.menu}
+ *   open={this.state.open}
+ *   onToggle={() => this.state.open = !this.state.open}
+ * />
+ * ```
+ */
+export class Dropdown extends Component<DropdownProps> {}
+export default Dropdown;

--- a/components/lib/Dropdown/Dropdown.d.ts
+++ b/components/lib/Dropdown/Dropdown.d.ts
@@ -156,5 +156,4 @@ export type DropdownProps = DropdownBaseProps &
  * />
  * ```
  */
-export class Dropdown extends Component<DropdownProps> {}
-export default Dropdown;
+export default class Dropdown extends Component<DropdownProps> {}

--- a/components/lib/Dropdown/index.d.ts
+++ b/components/lib/Dropdown/index.d.ts
@@ -1,1 +1,1 @@
-export { default as Dropdown, DropdownProps } from './Dropdown';
+export { default, DropdownProps } from './Dropdown';

--- a/components/lib/Dropdown/index.d.ts
+++ b/components/lib/Dropdown/index.d.ts
@@ -1,2 +1,1 @@
-declare const Dropdown: any;
-export default Dropdown;
+export { default as Dropdown, DropdownProps } from './Dropdown';

--- a/components/lib/HotKeys/index.d.ts
+++ b/components/lib/HotKeys/index.d.ts
@@ -1,2 +1,5 @@
-export const HotKeys: any;
-export const FocusTrap: any;
+import { HotKeys } from '@folio/stripes-react-hotkeys';
+
+export { HotKeys, FocusTrap } from '@folio/stripes-react-hotkeys';
+// TODO: export it from the module itself, pending https://github.com/folio-org/stripes-react-hotkeys/pull/36
+export type HotKeysProps = HotKeys['props'];

--- a/components/lib/Icon/Icon.d.ts
+++ b/components/lib/Icon/Icon.d.ts
@@ -1,0 +1,137 @@
+import {
+  AriaAttributes,
+  ComponentType,
+  ForwardRefExoticComponent,
+  PropsWithoutRef,
+  ReactNode,
+  RefAttributes,
+} from 'react';
+
+export type IconName =
+  | 'allocate'
+  | 'archive'
+  | 'arrow-down'
+  | 'arrow-left'
+  | 'arrow-right'
+  | 'arrow-up'
+  | 'bookmark'
+  | 'calendar'
+  | 'cancel'
+  | 'caret-down'
+  | 'caret-left'
+  | 'caret-right'
+  | 'caret-up'
+  | 'cart'
+  | 'check-circle'
+  | 'check-in'
+  | 'check-out'
+  | 'chevron-double-left'
+  | 'chevron-double-right'
+  | 'chevron-left'
+  | 'chevron-right'
+  | 'clipboard'
+  | 'clock'
+  | 'combine'
+  | 'comment'
+  | 'default'
+  | 'deselect-all'
+  | 'diacritic'
+  | 'document'
+  | 'download'
+  | 'drag-drop'
+  | 'duplicate'
+  | 'edit'
+  | 'ellipsis'
+  | 'end-mark'
+  | 'envelope'
+  | 'exclamation-circle'
+  | 'external-link'
+  | 'eye-closed'
+  | 'eye-open'
+  | 'flag'
+  | 'gear'
+  | 'house'
+  | 'indexes'
+  | 'info'
+  | 'lightning'
+  | 'link'
+  | 'lock'
+  | 'play'
+  | 'plus-sign'
+  | 'preview'
+  | 'print'
+  | 'profile'
+  | 'question-mark'
+  | 'receive'
+  | 'refresh'
+  | 'replace'
+  | 'report'
+  | 'save'
+  | 'search'
+  | 'select-all'
+  | 'source'
+  | 'spinner-ellipsis'
+  | 'tag'
+  | 'times-circle-solid'
+  | 'times-circle'
+  | 'times'
+  | 'transfer'
+  | 'trash'
+  | 'triangle-down'
+  | 'triangle-up'
+  | 'unlink';
+
+/**
+ * Custom icons must accept the following props
+ * (and pass them onto their `<svg>`)
+ */
+export interface CustomIconProps {
+  className: string;
+  viewBox: string;
+  focusable: boolean | 'true' | 'false';
+}
+
+/**
+ * An icon, to be rendered by `<Icon>`.  This supports a known icon name
+ * (see {@link IconName}) or a custom component that takes SVG props and
+ * returns a `<svg>`.
+ */
+export type IconType = IconName | ComponentType<CustomIconProps>;
+
+export interface IconProps extends AriaAttributes {
+  /**
+   * Specify an accessible label for the icon
+   * @deprecated use `aria-label` instead
+   */
+  ariaLabel?: AriaAttributes['aria-label'];
+  /** The icon to render, or a component for custom icons */
+  icon: IconType;
+  /** Applies a custom class name to the icon directly */
+  iconClassName?: string;
+  /** Applies a class to the internal wrapper div around the icon; useful for hover effects */
+  iconRootClass?: string;
+  /** Apply a style to the icon -- currently, `"action"` is the only supported style */
+  iconStyle?: 'action';
+  /** Set the outer element's ID */
+  id?: string;
+  /** Control the size of the icon */
+  size?: 'small' | 'medium' | 'large';
+  /** Give the icon a specific coloration */
+  status?: undefined | 'error' | 'warn' | 'success';
+  /** Set a custom tabIndex of the element */
+  tabIndex?: number;
+
+  /** Adds content next to the icon, useful for adding a label */
+  children: ReactNode;
+  /** Sets the position of the icon, for use with children */
+  iconPosition?: 'start' | 'end';
+}
+
+/**
+ * Renders a given icon
+ * @example <Icon icon="trash" />
+ */
+export const Icon: ForwardRefExoticComponent<
+  PropsWithoutRef<IconProps> & RefAttributes<HTMLSpanElement>
+>;
+export default Icon;

--- a/components/lib/Icon/index.d.ts
+++ b/components/lib/Icon/index.d.ts
@@ -1,2 +1,1 @@
-declare const Icon: any;
-export default Icon;
+export { default, IconProps } from './Icon';

--- a/components/lib/IconButton/IconButton.d.ts
+++ b/components/lib/IconButton/IconButton.d.ts
@@ -1,0 +1,100 @@
+import {
+  AriaAttributes,
+  CSSProperties,
+  ForwardRefExoticComponent,
+  MouseEventHandler,
+  PropsWithoutRef,
+  RefAttributes,
+} from 'react';
+import { RequireAllOrNone } from 'type-fest';
+import { BadgeProps } from '../Badge/Badge';
+import { IconType } from '../Icon/Icon';
+import { ButtonBaseProps } from '../Button/Button';
+
+export interface IconButtonBaseProps
+  extends AriaAttributes,
+    Pick<ButtonBaseProps, 'type' | 'href' | 'to'> {
+  /**
+   * Indicates whether the element (or a grouping it controls) is expanded
+   * @deprecated use `aria-label` instead
+   */
+  ariaExpanded?: AriaAttributes['aria-expanded'];
+  /**
+   * Indicates the availability and type of a popup element
+   * @deprecated use `aria-haspopup` instead
+   */
+  ariaHasPopup?: AriaAttributes['aria-haspopup'];
+  /**
+   * Provides a custom label for the element
+   * @deprecated use `aria-label` instead
+   */
+  ariaLabel?: AriaAttributes['aria-label'];
+  /**
+   * Identify the element which labels the current element
+   * @deprecated use `aria-labelledby` instead
+   */
+  ariaLabelledby?: AriaAttributes['aria-labelledby'];
+  /** If this button should be automatically focused */
+  autoFocus?: boolean;
+  /** Add a custom CSS class to the button */
+  className?: string;
+  /** The icon to display */
+  icon: IconType;
+  /** Adds a custom class name to the icon element */
+  iconClassName?: string;
+  /**
+   * Defines the size of the icon inside the button
+   * @see size for the size of the button itself
+   */
+  iconSize?: 'small' | 'medium';
+  /** Adds a custom ID to the icon */
+  id?: string;
+  /**
+   * Adds a custom class name to the middle element, between the outer
+   * button/anchor element and the icon itself
+   */
+  innerClassName?: string;
+  /** Handle an `onClick` event */
+  onClick?: MouseEventHandler<HTMLAnchorElement | HTMLButtonElement>;
+  /** Handle an `onMouseDown` event */
+  onMouseDown?: MouseEventHandler<HTMLAnchorElement | HTMLButtonElement>;
+  /**
+   * Defines the size of the button itself
+   * @see iconSize for the size of the icon
+   */
+  size?: 'small' | 'medium';
+  /** Set custom styles for the button */
+  style?: CSSProperties;
+  /** Control the tabIndex of the button */
+  tabIndex?: number;
+}
+
+// badgeColor may not be specified without badgeCount
+export interface IconButtonBadgeProps {
+  /**
+   * Sets the badge color
+   * @see badgeCount for the required content of the badge
+   */
+  badgeColor?: BadgeProps['color'];
+  /** Adds a badge with the given contents */
+  badgeCount: BadgeProps['children'];
+}
+
+export type IconButtonProps = IconButtonBaseProps &
+  RequireAllOrNone<IconButtonBadgeProps> &
+  (JSX.IntrinsicElements['a'] | JSX.IntrinsicElements['button']);
+
+/**
+ * Renders a given icon
+ * @example
+ * <IconButton
+ *   icon="comment"
+ *   badgeCount="3"
+ *   onClick={...}
+ * />
+ */
+export const IconButton: ForwardRefExoticComponent<
+  PropsWithoutRef<IconButtonProps> &
+    RefAttributes<HTMLAnchorElement | HTMLButtonElement>
+>;
+export default IconButton;

--- a/components/lib/IconButton/index.d.ts
+++ b/components/lib/IconButton/index.d.ts
@@ -1,2 +1,1 @@
-declare const IconButton: any;
-export default IconButton;
+export { default, IconButtonProps } from './IconButton';

--- a/components/lib/MultiColumnList/EndOfList.d.ts
+++ b/components/lib/MultiColumnList/EndOfList.d.ts
@@ -1,2 +1,4 @@
-declare const EndOfList: any;
+import { ComponentType } from 'react';
+
+declare const EndOfList: ComponentType<Record<string, never>>;
 export default EndOfList;

--- a/components/lib/MultiColumnList/MCLRenderer.d.ts
+++ b/components/lib/MultiColumnList/MCLRenderer.d.ts
@@ -1,0 +1,2 @@
+// TODO
+export const pagingTypes: any;

--- a/components/lib/MultiColumnList/MultiColumnList.d.ts
+++ b/components/lib/MultiColumnList/MultiColumnList.d.ts
@@ -143,37 +143,52 @@ export interface MultiColumnListBaseProps<
 export type MultiColumnListHeaderClickProps<
   DataShape,
   OmittedColumns extends string
-> = RequireAllOrNone<{
-  /** Columns to disallow clicking */
-  nonInteractiveHeaders?: (keyof Omit<DataShape, OmittedColumns>)[];
-  /** Callback for when a column is clicked */
-  onHeaderClick: (
-    e: MouseEvent,
-    meta: { name: keyof Omit<DataShape, OmittedColumns>; alias: ReactNode }
-  ) => void;
-}>;
+> = RequireAllOrNone<
+  {
+    /** Columns to disallow clicking */
+    nonInteractiveHeaders?: (keyof Omit<DataShape, OmittedColumns>)[];
+    /** Callback for when a column is clicked */
+    onHeaderClick: (
+      e: MouseEvent,
+      meta: { name: keyof Omit<DataShape, OmittedColumns>; alias: ReactNode }
+    ) => void;
+  },
+  'nonInteractiveHeaders' | 'onHeaderClick'
+>;
 
 export type MultiColumnListSpecialPagingTypes =
-  | RequireAllOrNone<{
-      pagingType: 'click';
-      /** If there is no more data available */
-      dataEndReached?: boolean;
-      /** A custom label for the load more button */
-      pagingButtonLabel?: ReactNode;
-    }>
-  | RequireAllOrNone<{
-      pagingType: 'prev-next';
-      pagingCanGoNext?: boolean;
-      pagingCanGoPrevious?: boolean;
-      hidePageIndices?: boolean;
-    }>;
+  | RequireAllOrNone<
+      {
+        pagingType: 'click';
+        /** If there is no more data available */
+        dataEndReached?: boolean;
+        /** A custom label for the load more button */
+        pagingButtonLabel?: ReactNode;
+      },
+      'pagingType' | 'dataEndReached' | 'pagingButtonLabel'
+    >
+  | RequireAllOrNone<
+      {
+        pagingType: 'prev-next';
+        pagingCanGoNext?: boolean;
+        pagingCanGoPrevious?: boolean;
+        hidePageIndices?: boolean;
+      },
+      | 'pagingType'
+      | 'pagingCanGoNext'
+      | 'pagingCanGoPrevious'
+      | 'hidePageIndices'
+    >;
 
-export type MultiColumnListMarkProps = RequireAllOrNone<{
-  /** Scroll to a given item */
-  itemToView: PositionObject;
-  /** Callback for when a row from itemToView could not be focused */
-  onMarkReset?: () => void;
-}>;
+export type MultiColumnListMarkProps = RequireAllOrNone<
+  {
+    /** Scroll to a given item */
+    itemToView: PositionObject;
+    /** Callback for when a row from itemToView could not be focused */
+    onMarkReset?: () => void;
+  },
+  'itemToView' | 'onMarkReset'
+>;
 
 export type MultiColumnListProps<
   DataShape,

--- a/components/lib/MultiColumnList/MultiColumnList.d.ts
+++ b/components/lib/MultiColumnList/MultiColumnList.d.ts
@@ -1,0 +1,212 @@
+import {
+  Component,
+  CSSProperties,
+  FunctionComponent,
+  ReactNode,
+  RefObject,
+  UIEventHandler,
+} from 'react';
+import { RequireAllOrNone } from 'type-fest';
+import { HotKeysProps } from '../HotKeys';
+import { MultiColumnListRowFormatterProps } from './defaultRowFormatter';
+
+export type ColumnWidth =
+  | CSSProperties['width']
+  | {
+      min: number;
+      max?: number;
+    };
+export interface PositionObject {
+  /** Number of pixels from the top of the screen to add above the item being scrolled to */
+  localClientTop: number;
+  /** Selector to match the row, likely something like `[aria-rowindex="${rowIndex}"]` */
+  selector: string;
+}
+
+export type PagingType = 'click' | 'none' | 'prev-next' | 'scroll';
+
+export interface MultiColumnListBaseProps<
+  DataShape,
+  OmittedColumns extends string
+> {
+  /** If the list should fill the containing element (e.g. filling the full width/height of a pane) */
+  autosize?: boolean;
+  /**
+   * Adds a prefix to column header IDs (otherwise MCLs with conflicting column
+   * header names in the same view could cause issues)
+   */
+  columnIdPrefix?: string;
+  /** Maps data fields to labels for column headers */
+  columnMapping?: Record<keyof Omit<DataShape, OmittedColumns>, ReactNode>;
+  /** If a column should show overflow */
+  columnOverflow?: Record<keyof Omit<DataShape, OmittedColumns>, boolean>;
+  /** Set widths for columns, either as direct widths or min/max pixels */
+  columnWidths?: Record<keyof Omit<DataShape, OmittedColumns>, ColumnWidth>;
+  /** A ref to the MCL's container */
+  containerRef?: RefObject<HTMLDivElement>;
+  /** The list's data */
+  contentData: DataShape[];
+  /** Custom functions that render the nodes for each column */
+  formatter?: Record<
+    keyof Omit<DataShape, OmittedColumns>,
+    (item: DataShape) => ReactNode
+  >;
+  /** Replaces the default classes with the result of this function */
+  getCellClass?: (
+    defaultClasses: string,
+    rowData: DataShape,
+    header: keyof Omit<DataShape, OmittedColumns>
+  ) => string;
+  /** Adds additional classes to the default header's classes */
+  getHeaderCellClass?: (
+    columnName: keyof Omit<DataShape, OmittedColumns>
+  ) => string;
+  /** Replaces the default row container classes with the result of this function */
+  getRowContainerClass?: (defaultClasses: string) => string;
+  /** Adds horizontal margin to the rows and header */
+  hasMargin?: boolean;
+  /**
+   * TODO: unknown, see
+   * https://folio-project.slack.com/archives/C210UCHQ9/p1655355343636399?thread_ts=1589556430.060600&cid=C210UCHQ9
+   */
+  headerMetadata?: unknown;
+  /** Adds a class to the header row */
+  headerRowClass?: string;
+  /** Set the height of the container */
+  height?: CSSProperties['height'];
+  /** Add custom hotkeys to the list */
+  hotKeys?: Pick<HotKeysProps, 'keyMap' | 'handlers'>;
+  /** Override the default id for the MCL */
+  id?: string;
+  /** Function to pass the instance to */
+  instanceRef?: (instance: MultiColumnList<DataShape, OmittedColumns>) => void;
+  /** If rows should display as hoverable/clickable */
+  interactive?: boolean;
+  /** The message to display if the MCL is empty */
+  isEmptyMessage?: ReactNode;
+  /** Function to determine if a row should show as selected */
+  isSelected?: (args: { item: DataShape; rowIndex: number }) => boolean;
+  /** If a loading icon should be shown at the bottom of the list */
+  loading?: boolean;
+  /** A maximum height for the MCL, in pixels */
+  maxHeight?: number;
+  /** The minimum height of any row, in pixels */
+  minimumRowHeight?: number;
+  /** Callback for a row being focused */
+  onMarkPosition?: (itemToView: PositionObject) => void;
+  /** Callback to request more data to be loaded */
+  onNeedMoreData?: (askAmount: number, index: number) => void;
+  /** Callback for when a row is clicked */
+  onRowClick?: (e: MouseEvent | KeyboardEvent, row: DataShape) => void;
+  /** Callback for when the list is scrolled */
+  onScroll?: UIEventHandler<HTMLDivElement>;
+  /** The amount to request at a time from `onNeedMoreData` */
+  pageAmount?: number;
+  /** The method for pagination */
+  pagingType?: PagingType;
+  /** A custom formatter for an entire row */
+  // TODO: add default formatter types/extension here
+  rowFormatter?: FunctionComponent<MultiColumnListRowFormatterProps<DataShape>>;
+  /** Keys in the data that should not be rendered */
+  rowMetadata?: OmittedColumns[];
+  /**
+   * A function that can force a row to re-render by changing its return.  This return is passed
+   * directly to a pure row's props, so any change will cause a re-render.  The actual value does
+   * not matter
+   */
+  rowUpdater?: (rowData: DataShape, rowIndex: number) => unknown;
+  /** Override styles for selected rows */
+  selectedClass?: string;
+  /**
+   * The selected row, should match a row from {@link contentData}
+   * @deprecated use {@link isSelected} instead
+   */
+  selectedRow?: DataShape;
+  /** Which way a sorted column is sorted */
+  sortDirection?: 'ascending' | 'descending';
+  /** The column being styled as sorted */
+  sortedColumn?: keyof Omit<DataShape, OmittedColumns>;
+  /** If alternating rows should have different colors, resulting in a striped appearance */
+  striped?: boolean;
+  /** The total number of rows, for virtualization or pagination */
+  totalCount?: number;
+  /** For large tables, do not render all rows into the DOM at once */
+  virtualize?: boolean;
+  /** A list of columns that should be rendered, takes precedence over {@link rowMetadata} */
+  visibleColumns?: (keyof Omit<DataShape, OmittedColumns>)[];
+  /** Set the MCL's width */
+  width?: number;
+  /** If cells should wrap within themselves */
+  wrapCells?: boolean;
+}
+
+export type MultiColumnListHeaderClickProps<
+  DataShape,
+  OmittedColumns extends string
+> = RequireAllOrNone<{
+  /** Columns to disallow clicking */
+  nonInteractiveHeaders?: (keyof Omit<DataShape, OmittedColumns>)[];
+  /** Callback for when a column is clicked */
+  onHeaderClick: (
+    e: MouseEvent,
+    meta: { name: keyof Omit<DataShape, OmittedColumns>; alias: ReactNode }
+  ) => void;
+}>;
+
+export type MultiColumnListSpecialPagingTypes =
+  | RequireAllOrNone<{
+      pagingType: 'click';
+      /** If there is no more data available */
+      dataEndReached?: boolean;
+      /** A custom label for the load more button */
+      pagingButtonLabel?: ReactNode;
+    }>
+  | RequireAllOrNone<{
+      pagingType: 'prev-next';
+      pagingCanGoNext?: boolean;
+      pagingCanGoPrevious?: boolean;
+      hidePageIndices?: boolean;
+    }>;
+
+export type MultiColumnListMarkProps = RequireAllOrNone<{
+  /** Scroll to a given item */
+  itemToView: PositionObject;
+  /** Callback for when a row from itemToView could not be focused */
+  onMarkReset?: () => void;
+}>;
+
+export type MultiColumnListProps<
+  DataShape,
+  OmittedColumns extends string
+> = MultiColumnListBaseProps<DataShape, OmittedColumns> &
+  MultiColumnListHeaderClickProps<DataShape, OmittedColumns> &
+  MultiColumnListSpecialPagingTypes &
+  MultiColumnListMarkProps;
+
+/**
+ * Renders an array of data objects as a table where each object is a row and each property of the
+ * objects is a column. Capable of virtualizing rows in large collections of data.
+ * @example
+ * const catalogResults = [
+ *     {title:'Microbiology Today', author:'James Edward'},
+ *     {title:'Orange Book', author:'Philip Ramos'},
+ * ]
+ * <MultiColumnList contentData={catalogResults} />
+ * @example
+ * <MultiColumnList
+ *   contentData={...}
+ *   visibleColumns={['actionDate', 'action', 'dueDate', 'itemStatus', 'source']}
+ *   columnMapping={{
+ *     action: <FormattedMessage id="ui-users.loans.columns.action" />,
+ *     actionDate: <FormattedMessage id="ui-users.loans.columns.actionDate" />,
+ *     dueDate: <FormattedMessage id="ui-users.loans.columns.dueDate" />,
+ *     itemStatus: <FormattedMessage id="ui-users.loans.columns.itemStatus" />,
+ *     source: <FormattedMessage id="ui-users.loans.columns.source" />,
+ *   }}
+ * />
+ */
+export class MultiColumnList<
+  DataShape,
+  OmittedColumns extends string = ''
+> extends Component<MultiColumnListProps<DataShape, OmittedColumns>> {}
+export default MultiColumnList;

--- a/components/lib/MultiColumnList/defaultRowFormatter.d.ts
+++ b/components/lib/MultiColumnList/defaultRowFormatter.d.ts
@@ -1,0 +1,27 @@
+import {
+  CSSProperties,
+  KeyboardEventHandler,
+  MouseEventHandler,
+  ReactNode,
+} from 'react';
+
+export interface MultiColumnListRowFormatterProps<DataShape> {
+  cells: ReactNode[];
+  labelStrings:
+    | string[]
+    | ((props: MultiColumnListRowFormatterProps<DataShape>) => string[]);
+  rowClass: string;
+  rowData: DataShape;
+  rowIndex: number;
+  rowProps: {
+    onClick: MouseEventHandler;
+    onKeyDown: KeyboardEventHandler;
+    style: CSSProperties;
+    'data-row-inner': number;
+  };
+  rowWidth: number;
+}
+
+export default function defaultRowFormatter<
+  DataShape = Record<string, unknown>
+>(props: MultiColumnListRowFormatterProps<DataShape>): JSX.Element;

--- a/components/lib/MultiColumnList/index.d.ts
+++ b/components/lib/MultiColumnList/index.d.ts
@@ -1,5 +1,6 @@
-export const pagingTypes: any;
-export const DefaultMCLRowFormatter: any;
-
-declare const MultiColumnList: any;
-export default MultiColumnList;
+export { pagingTypes } from './MCLRenderer';
+export {
+  default as DefaultMCLRowFormatter,
+  MultiColumnListRowFormatterProps,
+} from './defaultRowFormatter';
+export { default, MultiColumnListProps } from './MultiColumnList';

--- a/components/lib/Pane/Pane.d.ts
+++ b/components/lib/Pane/Pane.d.ts
@@ -1,0 +1,147 @@
+import {
+  AriaAttributes,
+  Component,
+  CSSProperties,
+  ElementType,
+  ReactNode,
+  RefObject,
+} from 'react';
+import { SetOptional } from 'type-fest';
+import { PaneHeaderDefaultProps } from '../PaneHeader/PaneHeader';
+
+export interface PaneProps extends AriaAttributes {
+  /**
+   * Activates the action menu dropdown; function must return a node/component
+   * (probably a `<MenuSection>`)
+   * @deprecated use {@link renderHeader} instead
+   */
+  actionMenu?: PaneHeaderDefaultProps['actionMenu'];
+  /**
+   * Adds an icon to the header.  Expects an `<AppIcon>` from `stripes-core`.
+   * @deprecated use {@link renderHeader} instead
+   */
+  appIcon?: PaneHeaderDefaultProps['appIcon'];
+  /**
+   * Wraps the contents in a centered container -- useful in large panes where
+   * you do not want the content to fill the pane's entire width
+   */
+  centerContent?: boolean;
+  /** The pane's contents */
+  children: ReactNode;
+  /**
+   * The percentage of the paneset that should be occupied,
+   * or `fill` to use all available space
+   */
+  defaultWidth: `${number}%` | 'fill';
+  /**
+   * If a close (x) button should be rendered in the pane's header:
+   * - A `false` value will not render a button
+   * - A `true` value will render a button in the firstMenu (left side in ltr languages)
+   * - A `"last"` value will render a button in the lastMenu (right side in ltr languages)
+   * @deprecated use {@link renderHeader} instead
+   */
+  dismissible?: PaneHeaderDefaultProps['dismissible'];
+  /**
+   * Component (probably a `<PaneMenu>`) to render at the beginning of the header
+   * (top left in ltr languages)
+   * @deprecated use {@link renderHeader} instead
+   */
+  firstMenu?: PaneHeaderDefaultProps['firstMenu'];
+  /** If true, removes the default min-width applied to the pane's contents */
+  fluidContentWidth?: boolean;
+  /** A node (likely a <PaneFooter>) to render at the bottom of the pane */
+  footer?: ReactNode;
+  /** The height of the pane, not to exceed `100vh` (used for the universal FOLIO header) */
+  height?: CSSProperties['height'];
+  /** Specify an ID to use for the Pane */
+  id?: string;
+  /**
+   * Component (probably a `<PaneMenu>`) to render at the end of the header
+   * (top right in ltr languages)
+   * @deprecated use {@link renderHeader} instead
+   */
+  lastMenu?: PaneHeaderDefaultProps['lastMenu'];
+  /**
+   * If the pane is not expected to scroll.  If true, scrollbars will be
+   * hidden, fixing some issues in result panes and the like.
+   */
+  noOverflow?: boolean;
+  /**
+   * Callback for when the pane is closed using its close button (see `dismissible` prop)
+   * @deprecated use {@link renderHeader} instead
+   */
+  onClose?: () => void;
+  /** Callback for when the pane is mounted */
+  onMount?: (args: {
+    paneRef: RefObject<HTMLElement>;
+    paneTitleRef: RefObject<HTMLDivElement>;
+  }) => void;
+  /** If the pane's contents should be padded */
+  padContent?: boolean;
+  /**
+   * Add a subtitle to the pane, as a node or string (recommended).
+   * @deprecated use {@link renderHeader} instead
+   */
+  paneSub?: PaneHeaderDefaultProps['paneSub'];
+  /**
+   * Add a title to the pane, as a node or string (recommended).
+   * This will be enclosed with a `<h2>` for accessibility
+   * @deprecated use {@link renderHeader} instead
+   */
+  paneTitle?: PaneHeaderDefaultProps['paneTitle'];
+  /**
+   * A reference to the header of the pane
+   * @deprecated use {@link renderHeader} instead
+   */
+  paneTitleRef?: PaneHeaderDefaultProps['paneTitleRef'];
+  /**
+   * A function to render a `<PaneHeader>`.  This is the preferred method
+   * over providing props to the `<Pane>` itself.  The parameters are props
+   * that were passed to this pane but belong to the header, so should
+   * probably be spread to your custom `<PaneHeader>` before your props.
+   * This method will eventually be the only supported method.
+   */
+  renderHeader?: (
+    renderProps: Pick<
+      SetOptional<PaneHeaderDefaultProps, keyof PaneHeaderDefaultProps>,
+      | 'paneTitle'
+      | 'paneTitleRef'
+      | 'paneSub'
+      | 'appIcon'
+      | 'firstMenu'
+      | 'lastMenu'
+      | 'actionMenu'
+      | 'dismissible'
+      | 'onClose'
+      | 'id'
+    >
+  ) => ReactNode;
+  /** Render something immediately beneath the main pane header (likely a <PaneSubheader>) */
+  subheader?: ReactNode;
+  /** Use a custom element for the root element of the pane */
+  tagName?: ElementType;
+  /** Set the transition of the pane */
+  transition?: 'none' | 'slide';
+}
+
+/**
+ * A pane, central to FOLIO module layout.
+ * @example
+ * <Pane
+ *   defaultWidth="20%"
+ *   paneTitle="Filters"
+ * >
+ *   Pane Content
+ * </Pane>
+ * <Pane
+ *   defaultWidth="fill"
+ *   padContent={false} // prevent horizontal scrolling
+ *   noOverflow         // at the pane level (useful in case the rendered content, like a results list, handles this.)
+ *   // Render a custom header using the "renderHeader"-prop if needed
+ *   renderHeader={renderProps => <PaneHeader {...renderProps} paneTitle="Search Results" />}
+ * >
+ *   Pane Content
+ * </Pane>
+ */
+export class Pane extends Component<PaneProps> {}
+export default Pane;

--- a/components/lib/Pane/index.d.ts
+++ b/components/lib/Pane/index.d.ts
@@ -1,2 +1,1 @@
-declare const Pane: any;
-export default Pane;
+export { default, PaneProps } from './Pane';

--- a/components/lib/PaneBackLink/PaneBackLink.d.ts
+++ b/components/lib/PaneBackLink/PaneBackLink.d.ts
@@ -1,0 +1,28 @@
+import { ComponentType } from 'react';
+import { SetOptional } from 'type-fest';
+import { PaneHeaderIconButtonProps } from '../PaneHeaderIconButton/PaneHeaderIconButton';
+
+// The icon is `arrow-left` by default
+export type PaneBackLinkProps = SetOptional<PaneHeaderIconButtonProps, 'icon'>;
+
+/**
+ * Renders a left arrow used to close panes on smaller screens (hidden above `medium` breakpoint).
+ * All props are passed to the internal `IconButton`.
+ * @example
+ * <Pane
+ *   renderHeader={renderProps => (
+ *     <PaneHeader
+ *       {...renderProps}
+ *       firstMenu={
+ *         <PaneMenu>
+ *           <PaneBackLink to="/my-module-root" />
+ *         </PaneMenu>
+ *       }
+ *     />
+ *   )}
+ * >
+ * ...
+ * </Pane>
+ */
+export const PaneBackLink: ComponentType<PaneBackLinkProps>;
+export default PaneBackLink;

--- a/components/lib/PaneBackLink/index.d.ts
+++ b/components/lib/PaneBackLink/index.d.ts
@@ -1,2 +1,1 @@
-declare const PaneBackLink: any;
-export default PaneBackLink;
+export { default, PaneBackLinkProps } from './PaneBackLink';

--- a/components/lib/PaneCloseLink/PaneCloseLink.d.ts
+++ b/components/lib/PaneCloseLink/PaneCloseLink.d.ts
@@ -1,0 +1,28 @@
+import { FunctionComponent } from 'react';
+import { SetOptional } from 'type-fest';
+import { PaneHeaderIconButtonProps } from '../PaneHeaderIconButton/PaneHeaderIconButton';
+
+// The icon is `arrow-left` or `times` by default
+export type PaneCloseLinkProps = SetOptional<PaneHeaderIconButtonProps, 'icon'>;
+
+/**
+ * Renders a left arrow used to close panes on smaller screens and a `x` icon
+ * on larger screens.  All props are passed to the internal `IconButton`.
+ * @example
+ * <Pane
+ *   renderHeader={renderProps => (
+ *     <PaneHeader
+ *       {...renderProps}
+ *       firstMenu={
+ *         <PaneMenu>
+ *           <PaneCloseLink to="/my-module-root" />
+ *         </PaneMenu>
+ *       }
+ *     />
+ *   )}
+ * >
+ * ...
+ * </Pane>
+ */
+export const PaneCloseLink: FunctionComponent<PaneCloseLinkProps>;
+export default PaneCloseLink;

--- a/components/lib/PaneCloseLink/index.d.ts
+++ b/components/lib/PaneCloseLink/index.d.ts
@@ -1,2 +1,1 @@
-declare const PaneCloseLink: any;
-export default PaneCloseLink;
+export { default, PaneCloseLinkProps } from './PaneCloseLink';

--- a/components/lib/PaneFooter/DefaultPaneFooter.d.ts
+++ b/components/lib/PaneFooter/DefaultPaneFooter.d.ts
@@ -1,0 +1,26 @@
+import { FunctionComponent, ReactNode } from 'react';
+
+export interface PaneFooterBaseProps {
+  /** Sets the class name of the main footer element */
+  className?: string;
+}
+
+export interface PaneFooterChildrenContentsProps {
+  /** The contents of the footer */
+  children: ReactNode;
+}
+
+export interface DefaultPaneFooterProps {
+  /** Adds class name(s) to the footer */
+  className?: string;
+  /** Node(s) to render at the start of the footer */
+  renderStart?: ReactNode;
+  /** Node(s) to render at the end of the footer */
+  renderEnd?: ReactNode;
+}
+
+/**
+ * Renders a pane footer with the given nodes at the start and end
+ */
+export const DefaultPaneFooter: FunctionComponent<DefaultPaneFooterProps>;
+export default DefaultPaneFooter;

--- a/components/lib/PaneFooter/PaneFooter.d.ts
+++ b/components/lib/PaneFooter/PaneFooter.d.ts
@@ -1,0 +1,68 @@
+import {
+  Component,
+  ForwardRefExoticComponent,
+  PropsWithoutRef,
+  ReactNode,
+  RefAttributes,
+} from 'react';
+import { DefaultPaneFooterProps } from './DefaultPaneFooter';
+
+export interface PaneFooterBaseProps {
+  /** Sets the class name of the main footer element */
+  className?: string;
+  /** Overrides the component/tag used for the footer */
+  element?: Component;
+}
+
+export interface PaneFooterChildrenContentsProps {
+  /** The contents of the footer */
+  children: ReactNode;
+}
+
+export interface PaneFooterBuiltinContentsProps
+  extends Omit<DefaultPaneFooterProps, 'className'> {
+  innerClassName: DefaultPaneFooterProps['className'];
+  /** Render at the start (left in LTR languages) of the footer */
+  renderStart?: ReactNode;
+  /** Render at the end (right in LTR languages) of the footer */
+  renderEnd?: ReactNode;
+}
+
+export type PaneFooterProps = PaneFooterBaseProps &
+  (PaneFooterChildrenContentsProps | PaneFooterBuiltinContentsProps);
+
+/**
+ * Renders a footer at the bottom of a pane.  Props may be used to render
+ * at the start or end of the footer, or custom children can be passed.
+ * @example
+ * const footer = (
+ *   <PaneFooter
+ *     renderStart={<Button>Cancel</Button>}
+ *     renderEnd={<Button>Save</Button>}
+ *     className={css.paneFooterClass}
+ *     innerClassName={css.paneFooterContentClass}
+ *   />
+ * );
+ *
+ * <Pane footer={footer} ... >
+ *   Pane Content
+ * </Pane>
+ * @example
+ * <PaneFooter footerClass={css.paneFooter}>
+ *   <div className={css.paneFooterContent}>
+ *     <Button onClick={() => {...}}>
+ *       Cancel
+ *     </Button>
+ *     <Button
+ *       buttonStyle="primary"
+ *       type="submit"
+ *     >
+ *       Save
+ *     </Button>
+ *   </div>
+ * </PaneFooter>
+ */
+export const PaneFooter: ForwardRefExoticComponent<
+  PropsWithoutRef<PaneFooterProps> & RefAttributes<HTMLDivElement>
+>;
+export default PaneFooter;

--- a/components/lib/PaneFooter/index.d.ts
+++ b/components/lib/PaneFooter/index.d.ts
@@ -1,2 +1,1 @@
-declare const PaneFooter: any;
-export default PaneFooter;
+export { default, PaneFooterProps } from './PaneFooter';

--- a/components/lib/PaneHeader/PaneHeader.d.ts
+++ b/components/lib/PaneHeader/PaneHeader.d.ts
@@ -1,0 +1,80 @@
+import { FunctionComponent, ReactNode, RefObject } from 'react';
+import { DropdownMenuFunction } from '../Dropdown/Dropdown';
+
+export interface PaneHeaderDefaultProps {
+  /**
+   * Activates the action menu dropdown; function must return a node/component
+   * (probably a `<MenuSection>`)
+   */
+  actionMenu?: DropdownMenuFunction;
+  /** Adds an icon to the header.  Expects an `<AppIcon>` from `stripes-core`. */
+  appIcon?: ReactNode;
+  /**
+   * If a close (x) button should be rendered in the pane's header:
+   * - A `false` value will not render a button
+   * - A `true` value will render a button in the firstMenu (left side in ltr languages)
+   * - A `"last"` value will render a button in the lastMenu (right side in ltr languages)
+   */
+  dismissible?: boolean | 'last';
+  /**
+   * Component (probably a `<PaneMenu>`) to render at the beginning of the header
+   * (top left in ltr languages)
+   */
+  firstMenu?: ReactNode;
+  /** Specify an ID to use for the PaneHeader */
+  id?: string;
+  /**
+   * Component (probably a `<PaneMenu>`) to render at the end of the header
+   * (top right in ltr languages)
+   */
+  lastMenu?: ReactNode;
+  /** Callback for when the pane is closed using its close button (see `dismissible` prop) */
+  onClose?: () => void;
+  /** Add a subtitle to the pane, as a node or string (recommended). */
+  paneSub?: ReactNode;
+  /**
+   * Add a title to the pane, as a node or string (recommended).
+   * This will be enclosed with a `<h2>` for accessibility
+   */
+  paneTitle?: ReactNode;
+  /** If the title should be auto focused on mount */
+  paneTitleAutoFocus?: boolean;
+  /** A reference to the header of the pane */
+  paneTitleRef?: RefObject<HTMLDivElement>;
+}
+
+export interface PaneHeaderOverriddenProps {
+  /** Replace the entire builtin header with the provided node */
+  header: ReactNode;
+}
+
+export type PaneHeaderProps =
+  | PaneHeaderDefaultProps
+  | PaneHeaderOverriddenProps;
+
+/**
+ * A pane's header
+ * @example
+ * const renderHeader = renderProps => (
+ *   <PaneHeader
+ *     {...renderProps}
+ *     paneTitle="Pane header title"
+ *     paneSub="Pane header sub"
+ *     firstMenu={<PaneMenu />}
+ *     lastMenu={<PaneMenu />}
+ *     actionMenu={({ onToggle }) => { ... }}
+ *     appIcon={<AppIcon app="inventory" iconKey="holdings" />}
+ *   />
+ * );
+ *
+ * <Pane renderHeader={renderHeader}>
+ *   ...
+ * </Pane>
+ *
+ * // Render a <Pane> with no header
+ * <Pane renderHeader={null}>
+ *   ...
+ * </Pane>
+ */
+export const PaneHeader: FunctionComponent<PaneHeaderProps>;
+export default PaneHeader;

--- a/components/lib/PaneHeader/index.d.ts
+++ b/components/lib/PaneHeader/index.d.ts
@@ -1,2 +1,1 @@
-declare const PaneHeader: any;
-export default PaneHeader;
+export { default, PaneHeaderProps } from './PaneHeader';

--- a/components/lib/PaneHeaderIconButton/PaneHeaderIconButton.d.ts
+++ b/components/lib/PaneHeaderIconButton/PaneHeaderIconButton.d.ts
@@ -1,0 +1,17 @@
+import {
+  ForwardRefExoticComponent,
+  PropsWithoutRef,
+  RefAttributes,
+} from 'react';
+import { IconButtonProps } from '../IconButton/IconButton';
+
+export type PaneHeaderIconButtonProps = IconButtonProps;
+
+/**
+ * `PaneHeaderIconButton` is a variant of `IconButton` and accepts the same props.
+ */
+export const PaneHeaderIconButton: ForwardRefExoticComponent<
+  PropsWithoutRef<PaneHeaderIconButtonProps> &
+    RefAttributes<HTMLAnchorElement | HTMLButtonElement>
+>;
+export default PaneHeaderIconButton;

--- a/components/lib/PaneHeaderIconButton/index.d.ts
+++ b/components/lib/PaneHeaderIconButton/index.d.ts
@@ -1,2 +1,1 @@
-declare const PaneHeaderIconButton: any;
-export default PaneHeaderIconButton;
+export { default, PaneHeaderIconButtonProps } from './PaneHeaderIconButton';

--- a/components/lib/PaneMenu/PaneMenu.d.ts
+++ b/components/lib/PaneMenu/PaneMenu.d.ts
@@ -1,0 +1,29 @@
+import { FunctionComponent, ReactNode } from 'react';
+
+export interface PaneMenuProps {
+  /** The contents of the subheader */
+  children: ReactNode;
+}
+
+/**
+ * Wraps contents to prepare them for use as `firstMenu` or `lastMenu` on a `<Pane>`
+ * @example
+ * const firstMenu = (
+ *   <PaneMenu>
+ *     <PaneCloseLink />
+ *   </PaneMenu>
+ * );
+ *
+ * const lastMenu = (
+ *   <PaneMenu>
+ *     <PaneHeaderIconButton icon="bookmark" />
+ *   </PaneMenu>
+ * );
+ *
+ * <Pane
+ *   lastMenu={lastMenu}
+ *   firstMenu={firstMenu}
+ * > ... </Pane>
+ */
+export const PaneMenu: FunctionComponent<PaneMenuProps>;
+export default PaneMenu;

--- a/components/lib/PaneMenu/index.d.ts
+++ b/components/lib/PaneMenu/index.d.ts
@@ -1,2 +1,1 @@
-declare const PaneMenu: any;
-export default PaneMenu;
+export { default, PaneMenuProps } from './PaneMenu';

--- a/components/lib/PaneSubheader/PaneSubheader.d.ts
+++ b/components/lib/PaneSubheader/PaneSubheader.d.ts
@@ -1,0 +1,23 @@
+import { FunctionComponent, ReactNode } from 'react';
+
+export interface PaneSubheaderProps {
+  /** The contents of the subheader */
+  children: ReactNode;
+}
+
+/**
+ * Renders contents just below a pane's header but outside of the scrollable area
+ * @example
+ * const sbh = (
+ *   <PaneSubheader>
+ *     <SegmentedControl activeId="instanceLevel">
+ *       <Button id="instanceLevel">Instance</Button>
+ *       <Button id="holdingsLevel">Holdings</Button>
+ *       <Button id="itemsLevel">Items</Button>
+ *     </SegmentedControl>
+ *   </PaneSubheader>
+ * );
+ * <Pane subheader={sbh} ...> ... </Pane>
+ */
+export const PaneSubheader: FunctionComponent<PaneSubheaderProps>;
+export default PaneSubheader;

--- a/components/lib/PaneSubheader/index.d.ts
+++ b/components/lib/PaneSubheader/index.d.ts
@@ -1,2 +1,1 @@
-declare const PaneSubheader: any;
-export default PaneSubheader;
+export { default, PaneSubheaderProps } from './PaneSubheader';

--- a/components/lib/Paneset/Paneset.d.ts
+++ b/components/lib/Paneset/Paneset.d.ts
@@ -1,0 +1,98 @@
+import { Component, CSSProperties, ReactNode } from 'react';
+
+/**
+ * Maps a set of IDs (keys) to css widths (or `"fill"`)
+ */
+export type PanesetWidthSpecification = Record<
+  string,
+  CSSProperties['width'] | 'fill'
+>;
+
+export interface PanesetOnLayoutParameters {
+  /**
+   * The type of change that occurred.
+   * - `'added'` when a pane is added to the set
+   * - `'remove'` when a pane is removed from the set
+   * - `'paneset-resized'` when the entire paneset is resized
+   * - `'resize'` when an individual pane is resized
+   */
+  changeType: 'added' | 'removed' | 'paneset-resized' | 'resize';
+  /** An object with keys pertaining to the panes being rendered */
+  nextLayout: Record<string, 0>;
+  /** Whether or not there is an existing layout already cached (which would be preferred) */
+  layoutCached: boolean;
+  /** Readonly copy of the paneset's layout cache */
+  layoutCache: ReadonlyArray<PanesetWidthSpecification>;
+  /** The contents of the cached layout for this situation */
+  widths: PanesetWidthSpecification;
+}
+
+export interface PanesetOnResizeParameters {
+  /** The current panes/sizes */
+  currentLayout: PanesetWidthSpecification;
+  /** Readonly copy of the paneset's layout cache */
+  layoutCache: ReadonlyArray<PanesetWidthSpecification>;
+}
+
+export interface PanesetProps {
+  /** The panes within the paneset */
+  children?: ReactNode;
+  /**
+   * The initial size of the paneset, or `fill` to use all available space
+   */
+  defaultWidth?: `${number}%` | 'fill';
+  /** Specify an ID to use for the paneset */
+  id?: string;
+  initialLayouts?: PanesetWidthSpecification[];
+  /** If this paneset should not report to parent panesets, such as in a modal/layer */
+  isRoot?: boolean;
+  /** A custom function to determine pane widths */
+  onLayout?: (
+    params: PanesetOnLayoutParameters
+  ) => PanesetWidthSpecification | null;
+  /** A callback for when pane(s) are resized */
+  onResize?: (params: PanesetOnResizeParameters) => void;
+}
+
+/** nested and static cannot both be true */
+export type PanePositionProps =
+  | {
+      /** If a paneset is nested within another; applies relative positioning */
+      nested?: false;
+      /** Applies static positioning instead of absolute */
+      static: boolean;
+    }
+  | {
+      /** If a paneset is nested within another; applies relative positioning */
+      nested: boolean;
+      /** Applies static positioning instead of absolute */
+      static?: false;
+    }
+  | {
+      /** If a paneset is nested within another; applies relative positioning */
+      nested?: false;
+      /** Applies static positioning instead of absolute */
+      static?: false;
+    };
+
+/**
+ * A pane, central to FOLIO module layout.
+ * @example
+ * <Pane
+ *   defaultWidth="20%"
+ *   paneTitle="Filters"
+ * >
+ *   Pane Content
+ * </Pane>
+ * <Pane
+ *   defaultWidth="fill"
+ *   padContent={false} // prevent horizontal scrolling
+ *   noOverflow         // at the pane level (useful in case the rendered content, like a results list, handles this.)
+ *   // Render a custom header using the "renderHeader"-prop if needed
+ *   renderHeader={renderProps => <PaneHeader {...renderProps} paneTitle="Search Results" />}
+ * >
+ *   Pane Content
+ * </Pane>
+ */
+export class Paneset extends Component<PanesetProps> {}
+export default Paneset;

--- a/components/lib/Paneset/index.d.ts
+++ b/components/lib/Paneset/index.d.ts
@@ -1,2 +1,1 @@
-declare const Paneset: any;
-export default Paneset;
+export { default, PanesetProps } from './Paneset';

--- a/components/lib/Timepicker/Timepicker.d.ts
+++ b/components/lib/Timepicker/Timepicker.d.ts
@@ -1,0 +1,75 @@
+import Popper from 'popper.js';
+import { AriaAttributes, ComponentType, ReactNode, RefObject } from 'react';
+import { FieldRenderProps } from 'react-final-form';
+import { IntlShape } from 'react-intl';
+
+export interface TimepickerProps
+  extends AriaAttributes,
+    FieldRenderProps<string> {
+  /** If the field should auto-focus on mount */
+  autoFocus?: boolean;
+  /** Disables the input field */
+  disabled?: boolean;
+  /** Adds a custom ID to the control */
+  id?: string;
+  /** Ref to the internal text field */
+  inputRef?: RefObject<HTMLInputElement> | ((el: HTMLInputElement) => void);
+  /** Label the Timepicker */
+  label?: ReactNode;
+  /** Set the locale for use */
+  locale?: string;
+  /** Remove bottom margin */
+  marginBottom0?: boolean;
+  /** Popper modifiers */
+  modifiers?: Popper.Modifiers;
+  /** Fired anytime internal state changes */
+  onChange?: (e: Event, standardizedTime?: string) => void;
+  /** Format a UTC value into the specified timezone */
+  outputFormatter?: (props: {
+    value: string | undefined;
+    formats: string[];
+    timezone: string;
+    intl: IntlShape;
+  }) => string;
+  /** Parse a provided value into a given format */
+  parser?: (
+    value: string | undefined,
+    timezone: string,
+    timeFormat: string,
+    intl: IntlShape
+  ) => string;
+  /** Where the overlay should be placed in relation to the field */
+  placement?: Popper.Placement;
+  /** If the control is readonly */
+  readOnly?: boolean;
+  /** If the field is required */
+  required?: boolean;
+  /** Additional message to be read when the field is focused */
+  screenReaderMessage?: boolean;
+  /** If the picker should start off opened */
+  showTimepicker?: boolean;
+  /** Override the default timezone */
+  timeZone?: string;
+  /** Render to the global overlay, if the dropdown may be cut off due to some containing elements's overflow */
+  usePortal?: boolean;
+  /** The field's value */
+  value?: string;
+}
+
+/**
+ * A picker for times with an optional picker popup
+ * @example
+ * <Timepicker />
+ * // or pass as component within a form...
+ * <Field component={Timepicker} />
+ * @example
+ * <Field
+ *   name="exampleTimeReturned"
+ *   label="Time returned"
+ *   id="timeReturnTP"
+ *   placeholder="Select Time"
+ *   component={Timepicker}
+ * />
+ */
+declare const Timepicker: ComponentType<TimepickerProps>;
+export default Timepicker;

--- a/components/lib/Timepicker/index.d.ts
+++ b/components/lib/Timepicker/index.d.ts
@@ -1,2 +1,1 @@
-declare const Timepicker: any;
-export default Timepicker;
+export { default, TimepickerProps } from './Timepicker';

--- a/components/util/dateTimeUtils.d.ts
+++ b/components/util/dateTimeUtils.d.ts
@@ -1,4 +1,40 @@
-export const getMomentLocalizedFormat: any;
-export const getLocaleDateFormat: any;
-export const getLocalizedTimeFormatInfo: any;
-export const removeDST: any;
+import { IntlShape } from 'react-intl';
+
+export function getMomentLocalizedFormat(intl: IntlShape): string;
+
+/**
+ * Returns a localized format.
+ * Format will be a string similar to YYYY.MM.DD - something that can be
+ * passed to moment for parsing/formatting purposes.
+ */
+export function getLocaleDateFormat(params: { intl: IntlShape }): string;
+
+/**
+ * Accepts a locale like 'ar' or 'de'
+ * Gets an array of dayPeriods for 12 hour modes of time. The
+ * array items can be used as values for the day period control,
+ * and the array length used to determin 12 hour (2 items) or 24 hour mode (0 items).
+ *
+ * @example
+ * getLocalizedTimeFormatInfo('en-SE')
+ * // returns:
+ *   {
+ *     separator: ':',
+ *     timeFormat: 'HH:mm',
+ *     dayPeriods: [],  // no dayPeriods means 24 hour time format.
+ *   }
+ * @example
+ * getLocalizedTimeFormatInfo('en-US')
+ * // returns:
+ *   {
+ *     separator: ':',
+ *     timeFormat: 'HH:mm A',
+ *     dayPeriods: ['am', 'pm'], // day periods: 12 hour time format.
+ *   }
+ */
+export function getLocalizedTimeFormatInfo(locale: string | string[]): {
+  timeFormat: string;
+  dayPeriods: string[];
+};
+
+export function removeDST(dateTime: string, timeFormat: string): string;

--- a/package.json
+++ b/package.json
@@ -23,14 +23,12 @@
     "@types/react": "^17.0.2",
     "final-form": "^4.20.9",
     "popper.js": "^1.16.1",
-    "react": "^17.0.2",
     "react-final-form": "^6.5.9",
     "react-intl": "^6.4.1",
     "type-fest": "^3.9.0"
   },
-  "peerDependencies": {
-    "@types/react": "^17.0.2",
-    "react": "^17.0.2"
+  "resolutions": {
+    "@types/react": "^17.0.2"
   },
   "scripts": {
     "eslint": "eslint ./",

--- a/package.json
+++ b/package.json
@@ -19,10 +19,11 @@
   },
   "dependencies": {
     "@folio/eslint-config-stripes": "^6.4.0",
-    "@folio/stripes-react-hotkeys": "^3.0.100000026",
+    "@folio/stripes-react-hotkeys": "^3.0.0",
     "@types/react": "^17.0.2",
     "@types/react-router-dom": "^5.2.0",
     "final-form": "^4.20.9",
+    "moment": "^2.29.4",
     "popper.js": "^1.16.1",
     "react-final-form": "^6.5.9",
     "react-intl": "^6.4.1",

--- a/package.json
+++ b/package.json
@@ -19,8 +19,10 @@
   },
   "dependencies": {
     "@folio/eslint-config-stripes": "^6.4.0",
+    "@folio/stripes-react-hotkeys": "^3.0.100000026",
     "@types/react": "^17.0.2",
-    "react-final-form": "^6.5.9"
+    "react-final-form": "^6.5.9",
+    "type-fest": "^3.9.0"
   },
   "peerDependencies": {
     "@types/react": "^17.0.2",
@@ -28,9 +30,10 @@
   },
   "scripts": {
     "eslint": "eslint ./",
-    "test": "echo 'No tests implemented'"
+    "test": "tsc --noEmit --strict components/index.d.ts core/index.d.ts final-form/index.d.ts smart-components/index.d.ts"
   },
   "devDependencies": {
-    "eslint": "^8.38.0"
+    "eslint": "^8.38.0",
+    "typescript": "^5.0.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
     "@folio/stripes-react-hotkeys": "^3.0.100000026",
     "@types/react": "^17.0.2",
     "final-form": "^4.20.9",
+    "popper.js": "^1.16.1",
     "react-final-form": "^6.5.9",
+    "react-intl": "^6.4.1",
     "type-fest": "^3.9.0"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@types/react": "^17.0.2"
   },
   "scripts": {
-    "eslint": "eslint ./",
+    "lint": "eslint ./",
     "test": "tsc --noEmit --strict components/index.d.ts core/index.d.ts final-form/index.d.ts smart-components/index.d.ts"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@types/react": "^17.0.2",
     "final-form": "^4.20.9",
     "popper.js": "^1.16.1",
+    "react": "^17.0.2",
     "react-final-form": "^6.5.9",
     "react-intl": "^6.4.1",
     "type-fest": "^3.9.0"

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@folio/eslint-config-stripes": "^6.4.0",
     "@folio/stripes-react-hotkeys": "^3.0.100000026",
     "@types/react": "^17.0.2",
+    "final-form": "^4.20.9",
     "react-final-form": "^6.5.9",
     "type-fest": "^3.9.0"
   },

--- a/package.json
+++ b/package.json
@@ -21,11 +21,18 @@
     "@folio/eslint-config-stripes": "^6.4.0",
     "@folio/stripes-react-hotkeys": "^3.0.100000026",
     "@types/react": "^17.0.2",
+    "@types/react-router-dom": "^5.2.0",
     "final-form": "^4.20.9",
     "popper.js": "^1.16.1",
     "react-final-form": "^6.5.9",
     "react-intl": "^6.4.1",
     "type-fest": "^3.9.0"
+  },
+  "devDependencies": {
+    "eslint": "^8.38.0",
+    "react": "^17.0.2",
+    "react-router-dom": "^5.2.0",
+    "typescript": "^5.0.4"
   },
   "resolutions": {
     "@types/react": "^17.0.2"
@@ -33,9 +40,5 @@
   "scripts": {
     "lint": "eslint ./",
     "test": "tsc --noEmit --strict components/index.d.ts core/index.d.ts final-form/index.d.ts smart-components/index.d.ts"
-  },
-  "devDependencies": {
-    "eslint": "^8.38.0",
-    "typescript": "^5.0.4"
   }
 }


### PR DESCRIPTION
Adds:

- Button
- Dropdown
- HotKeys (re-export, needs fixing after https://github.com/folio-org/stripes-react-hotkeys/pull/36 per TODO)
- MultiColumnList and friends
- Pane and friends
- Datepicker
- Timepicker
- Icon
- IconButton

TODO: we should go through and document these props in the [MCL readme](https://github.com/folio-org/stripes-components/tree/master/lib/MultiColumnList), since many are lacking.  @nhanaa want to jump on that?

Quite a few other TODO's in here, unfortunately; I have not been able to properly verify these as of yet.

This _should_ be enough to get ui-calendar happy...hopefully