### PR TITLE
FOLIO-3876 BREAKING update react to v18 et al

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-types
 
+## 2.0.0 in progress
+
+* [FOLIO-3876] React 18
+
 ## [1.0.3] (https://github.com/folio-org/stripes-types/tree/v1.0.3) (2023-05-18)
 
 - [STCOM-1152] Add additional `stripes-components` typings

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-types",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "description": "Typings for the Stripes framework",
   "license": "Apache-2.0",
   "repository": "folio-org/stripes-types",
@@ -18,7 +18,6 @@
     }
   },
   "dependencies": {
-    "@folio/eslint-config-stripes": "^6.4.0",
     "@folio/stripes-react-hotkeys": "^3.0.0",
     "ky": "^0.33.3",
     "moment": "^2.29.4",
@@ -27,29 +26,24 @@
     "type-fest": "^3.9.0"
   },
   "devDependencies": {
+    "@folio/eslint-config-stripes": "^7.0.0",
+    "@types/react": "^18.2.21",
+    "@types/react-router-dom": "^5.3.3",
     "@typescript-eslint/eslint-plugin": "^5.59.2",
-    "@types/react": "^17.0.2",
-    "@types/react-router-dom": "^5.2.0",
-    "eslint": "^8.38.0",
     "final-form": "^4.20.9",
     "react": "^17.0.2",
+    "react-final-form": "^6.5.9",
     "react-intl": "^6.4.1",
     "react-router-dom": "^5.2.0",
-    "react-final-form": "^6.5.9",
-    "typescript": "^5.0.4"
+    "typescript": "^4.9.5"
   },
   "peerDependencies": {
-    "@types/react": "^17.0.2",
-    "@types/react-router-dom": "^5.2.0",
     "final-form": "^4.20.7",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "react-intl": "^6.4.1",
     "react-final-form": "^6.5.9",
+    "react-intl": "^6.4.1",
     "react-router-dom": "^5.2.0"
-  },
-  "resolutions": {
-    "@types/react": "^17.0.2"
   },
   "scripts": {
     "lint": "eslint ./",


### PR DESCRIPTION
* *BREAKING* react v18 and assorted other version updates
* remove resolutions since they will only be obeyed when installing deps within this repo, which is rare
* remove peers since types are only relevant at build time. what we really want is a dev-peer, but that's not a thing. if we specified peers here they will always be unsatisfied since the repos that depend on this one would only have such things as dev-deps, not direct-deps.
* lint is only used during dev, so eslint-config-stripes is only necessary as a dev-dep. removed eslint since it's provided by (and hoisted from) eslint-config-stripes.

Refs [FOLIO-3876](https://issues.folio.org/browse/FOLIO-3876)