### PR TITLE
Add Settings smart component, Stripes core utilities

### DIFF
--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -3,11 +3,9 @@ export const RootContext: any;
 export const withRoot: any;
 
 export { CalloutContext, useCallout } from './src/CalloutContext';
+export { StripesType, stripesShape, default as Stripes } from './src/Stripes';
+export { StripesContext, useStripes, withStripes } from './src/StripesContext';
 
-export const stripesShape: any;
-export const withStripes: any;
-export const useStripes: any;
-export const StripesContext: any;
 export const useModules: any;
 export const withModule: any;
 export const withModules: any;

--- a/core/src/Stripes.d.ts
+++ b/core/src/Stripes.d.ts
@@ -4,9 +4,28 @@ import { Requireable } from 'react';
 export interface StripesType {
   /**
    * Check if the current user has a given permission
+   *
+   * @returns undefined, if the user is not logged in or similar error
+   * @returns true, if the user has the permission
+   * @returns false, if the user does not have the permission
    * @see https://github.com/folio-org/stripes/blob/master/doc/dev-guide.md#testing-for-permission
    */
-  hasPerm(perm: string): boolean;
+  hasPerm(perm: string): boolean | undefined;
+
+  /**
+   * Check if an interface is available
+   *
+   * @returns undefined, on error
+   * @returns false, if the interface is not present
+   * @returns true, if the interface is available and no specific version was requested
+   * @returns the version string, if the interface and requested version is available
+   * @returns 0, if the interface is available but the requested version is not
+   * @see https://github.com/folio-org/stripes/blob/master/doc/dev-guide.md#testing-for-interfaces
+   */
+  hasInterface(
+    interface: string,
+    version?: string,
+  ): boolean | string | undefined;
 
   // TODO: fill this in with additional properties from Stripes object
   // https://github.com/folio-org/stripes/blob/master/doc/dev-guide.md#the-stripes-object
@@ -16,6 +35,11 @@ export interface StripesType {
 export const stripesShape: Requireable<StripesType>;
 
 export class Stripes implements StripesType {
-  hasPerm(perm: string): boolean;
+  hasPerm(perm: string): boolean | undefined;
+  hasInterface(
+    interface: string,
+    version?: string,
+  ): boolean | string | undefined;
+
   [key: string]: unknown;
 }

--- a/core/src/Stripes.d.ts
+++ b/core/src/Stripes.d.ts
@@ -1,0 +1,21 @@
+import { Requireable } from 'react';
+
+/** Type of the `stripes` object */
+export interface StripesType {
+  /**
+   * Check if the current user has a given permission
+   * @see https://github.com/folio-org/stripes/blob/master/doc/dev-guide.md#testing-for-permission
+   */
+  hasPerm(perm: string): boolean;
+
+  // TODO: fill this in with additional properties from Stripes object
+  // https://github.com/folio-org/stripes/blob/master/doc/dev-guide.md#the-stripes-object
+  [key: string]: unknown;
+}
+
+export const stripesShape: Requireable<StripesType>;
+
+export class Stripes implements StripesType {
+  hasPerm(perm: string): boolean;
+  [key: string]: unknown;
+}

--- a/core/src/Stripes.d.ts
+++ b/core/src/Stripes.d.ts
@@ -25,7 +25,7 @@ export interface StripesType {
   hasInterface(
     interface: string,
     version?: string,
-  ): boolean | string | undefined;
+  ): boolean | string | 0 | undefined;
 
   // TODO: fill this in with additional properties from Stripes object
   // https://github.com/folio-org/stripes/blob/master/doc/dev-guide.md#the-stripes-object
@@ -39,7 +39,7 @@ export class Stripes implements StripesType {
   hasInterface(
     interface: string,
     version?: string,
-  ): boolean | string | undefined;
+  ): boolean | string | 0 | undefined;
 
   [key: string]: unknown;
 }

--- a/core/src/StripesContext.d.ts
+++ b/core/src/StripesContext.d.ts
@@ -1,0 +1,10 @@
+import { ComponentType, Context } from 'react';
+import { StripesType } from '..';
+
+export const StripesContext: Context<StripesType>;
+
+export const useStripes: () => StripesType;
+
+export function withStripes<Props extends { stripes: StripesType }>(
+  component: ComponentType<Props>,
+): ComponentType<Omit<Props, 'stripes'>>;

--- a/smart-components/index.d.ts
+++ b/smart-components/index.d.ts
@@ -38,7 +38,9 @@ export const removeNsKeys: any;
 export const parseFilters: any;
 export const deparseFilters: any;
 export const buildUrl: any;
-export const Settings: any;
+
+export { default as Settings, SettingsProps } from './lib/Settings';
+
 export const Tags: any;
 export const withTags: any;
 export const TagsForm: any;

--- a/smart-components/lib/Settings/Settings.d.ts
+++ b/smart-components/lib/Settings/Settings.d.ts
@@ -1,0 +1,22 @@
+import { ReactNode, ComponentType, RefObject, Component } from 'react';
+import { PaneProps } from '../../../components';
+import { StripesType } from '../../../core';
+
+export interface SettingsProps {
+  additionalRoutes?: ReactNode[];
+  navPaneWidth?: PaneProps['defaultWidth'];
+  pages: {
+    route: string;
+    label: ReactNode;
+    component: ComponentType<Record<string, never>>;
+    perm?: string;
+  }[];
+  paneTitle?: ReactNode;
+  paneTitleRef?: RefObject<HTMLDivElement>;
+  location: Location;
+  showSettings?: boolean;
+  stripes: StripesType;
+  forceRender: number;
+}
+
+export class Settings extends Component<SettingsProps> {}

--- a/smart-components/lib/Settings/index.d.ts
+++ b/smart-components/lib/Settings/index.d.ts
@@ -1,0 +1,1 @@
+export { default, SettingsProps } from './Settings';


### PR DESCRIPTION
Adds typings for:
- smart component `Settings`
  - bonus `SettingsProps` interface
- core `StripesContext`
- core `useStripes`
- core `withStripes`
- core `stripesShape`
- core `Stripes` class
  - bonus `StripesType` interface (partially completed)