### PR TITLE
[STTYPES-6] [UILISTS-92] Add typings for SearchAndSort and friends

### DIFF
--- a/components/lib/AdvancedSearch/AdvancedSearch.d.ts
+++ b/components/lib/AdvancedSearch/AdvancedSearch.d.ts
@@ -78,4 +78,4 @@ export interface AdvancedSearchProps {
  * />
  * ```
  */
-export default function AdvancedSearch(props: AdvancedSearchProps): ReactNode;
+export default function AdvancedSearch(props: AdvancedSearchProps): JSX.Element;

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
   },
   "dependencies": {
     "@folio/stripes-react-hotkeys": "^3.0.0",
-    "apollo-client": "^2.6.10",
     "ky": "^0.33.3",
     "moment": "^2.29.4",
     "popper.js": "^1.16.1",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   },
   "dependencies": {
     "@folio/stripes-react-hotkeys": "^3.0.0",
+    "history": "^4.10.1",
     "ky": "^0.33.3",
     "moment": "^2.29.4",
     "popper.js": "^1.16.1",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   },
   "dependencies": {
     "@folio/stripes-react-hotkeys": "^3.0.0",
+    "apollo-client": "^2.6.10",
     "ky": "^0.33.3",
     "moment": "^2.29.4",
     "popper.js": "^1.16.1",

--- a/smart-components/index.d.ts
+++ b/smart-components/index.d.ts
@@ -18,26 +18,59 @@ export const LocationSelection: any;
 export const PasswordValidationField: any;
 export const PersistedPaneset: any;
 export const ProxyManager: any;
-export const SearchAndSort: any;
-export const SearchAndSortQuery: any;
-export const SearchAndSortNoResultsMessage: any;
-export const SearchAndSortResetButton: any;
-export const SearchAndSortSearchButton: any;
-export const CheckboxFilter: any;
-export const ExpandFilterPaneButton: any;
-export const CollapseFilterPaneButton: any;
-export const MultiSelectionFilter: any;
-export const DateRangeFilter: any;
-export const makeQueryFunction: any;
-export const makeConnectedSource: any;
-export const StripesConnectedSource: any;
-export const ApolloConnectedSource: any;
-export const getNsKey: any;
-export const mapNsKeys: any;
-export const removeNsKeys: any;
-export const parseFilters: any;
-export const deparseFilters: any;
-export const buildUrl: any;
+
+export { default as SearchAndSort, SearchAndSortProps } from './lib/SearchAndSort';
+export { default as SearchAndSortQuery } from './lib/SearchAndSort/SearchAndSortQuery';
+export {
+  default as SearchAndSortNoResultsMessage,
+  SearchAndSortNoResultsMessageProps,
+} from './lib/SearchAndSort/components/NoResultsMessage';
+export {
+  default as SearchAndSortResetButton,
+  SearchAndSortResetButtonProps,
+} from './lib/SearchAndSort/components/ResetButton';
+export {
+  default as SearchAndSortSearchButton,
+  SearchAndSortSearchButtonProps,
+} from './lib/SearchAndSort/components/SearchButton';
+export {
+  default as CheckboxFilter,
+  CheckboxFilterProps,
+} from './lib/SearchAndSort/components/CheckboxFilter';
+export {
+  default as ExpandFilterPaneButton,
+  ExpandFilterPaneButtonProps,
+} from './lib/SearchAndSort/components/ExpandFilterPaneButton';
+export {
+  default as CollapseFilterPaneButton,
+  CollapseFilterPaneButtonProps,
+} from './lib/SearchAndSort/components/CollapseFilterPaneButton';
+export {
+  default as MultiSelectionFilter,
+  MultiSelectionFilterProps,
+} from './lib/SearchAndSort/components/MultiSelectionFilter';
+export {
+  default as DateRangeFilter,
+  DateRangeFilterProps,
+} from './lib/SearchAndSort/components/DateRangeFilter';
+
+export { default as makeQueryFunction, QueryFunction } from './lib/SearchAndSort/makeQueryFunction';
+export { default as advancedSearchQueryToRows } from './lib/SearchAndSort/advancedSearchQueryToRows';
+
+export {
+  default as makeConnectedSource,
+  ConnectedSource,
+  ConnectedSourceProps,
+  ApolloConnectedSourceProps,
+  StripesConnectedSourceProps,
+} from './lib/SearchAndSort/ConnectedSource';
+export { default as StripesConnectedSource } from './lib/SearchAndSort/ConnectedSource/StripesConnectedSource';
+export { default as ApolloConnectedSource } from './lib/SearchAndSort/ConnectedSource/ApolloConnectedSource';
+
+export * from './lib/SearchAndSort/nsQueryFunctions';
+export * from './lib/SearchAndSort/parseFilters';
+
+export { default as buildUrl } from './lib/SearchAndSort/buildUrl';
 
 export { default as Settings, SettingsProps } from './lib/Settings';
 
@@ -62,6 +95,5 @@ export const useRemoteStorageMappings: any;
 export const useSetRef: any;
 export const useSetRefOnFocus: any;
 export const usePrevious: any;
-export const ColumnManager: any;
-export const ColumnManagerMenu: any;
-export const useColumnManager: any;
+
+export * from './lib/ColumnManager';

--- a/smart-components/lib/ColumnManager/ColumnManager.d.ts
+++ b/smart-components/lib/ColumnManager/ColumnManager.d.ts
@@ -1,0 +1,50 @@
+import { ReactNode } from 'react';
+
+export interface ColumnManagerProps {
+  /** The render-prop function that will receive the relevant props for implementing toggleable columns */
+  children: (props: {
+    /** An array of visible column keys that can be passed directly down to the `<MultiColumnList>` */
+    visibleColumns: string[];
+    /** Renders a <MenuSection> that wraps renderCheckboxes for toggling columns. This makes it easy to implement inside e.g. a pane action menu. */
+    renderColumnsMenu: ReactNode;
+    /** A method that toggles the visiblity for a given column – e.g. `toggleColumn('email')` */
+    toggleColumn: (key: string) => void;
+  }) => ReactNode;
+  /** An object that maps keys to labels. The order of the keys will determine the default order of the columns. */
+  columnMapping: Record<string, ReactNode>;
+  /** An array of keys to exclude from the list of toggleable columns */
+  excludeKeys?: string[];
+  /**
+   * The unique ID is used to generate the storage key for persisting the visible columns in sessionStorage.
+   * The ID will also be used as a prefixed ID for any UI that is passed down to the render-prop function.
+   */
+  id: string;
+  /** Whether or not to persist the visible columns in sessionStorage */
+  persist?: boolean;
+}
+
+/**
+ * A render-prop component for implementing toggleable columns in a `<MultiColumnList>`.
+ *
+ * @example
+ * ```
+ * const columnMapping = {
+ *     status: 'Status',
+ *     name: 'Name',
+ *     barcode: 'Barcode',
+ *     username: 'Username',
+ *     email: 'Email'
+ * };
+ *
+ * <ColumnManager
+ *     id="users-list-columns" // Required
+ *     columnMapping={columnMapping} // Required
+ *     excludeKeys={['name']} // Exclude these keys from being toggleable
+ * >
+ *     {({ visibleColumns, renderColumnsMenu, toggleColumn }) => {
+ *         // Render UI
+ *     }}
+ * </ColumnManager>
+ * ```
+ */
+export default function ColumnManager(props: ColumnManagerProps): JSX.Element;

--- a/smart-components/lib/ColumnManager/ColumnManagerMenu.d.ts
+++ b/smart-components/lib/ColumnManager/ColumnManagerMenu.d.ts
@@ -1,0 +1,17 @@
+import { ReactNode } from 'react';
+
+export interface ColumnManagerMenuProps {
+  /** An object that maps keys to labels */
+  columnMapping: Record<string, ReactNode>;
+  /** An array of keys to exclude from the list of columns */
+  excludeColumns?: string[];
+  /** Unique ID */
+  prefix: string;
+  /** An array of visible column keys */
+  visibleColumns: string[];
+}
+
+/**
+ * Renders an action menu section for toggling columns. Provided by `<ColumnManager>` as `renderColumnsMenu`.
+ */
+export default function ColumnManagerMenu(props: ColumnManagerMenuProps): JSX.Element;

--- a/smart-components/lib/ColumnManager/index.d.ts
+++ b/smart-components/lib/ColumnManager/index.d.ts
@@ -1,0 +1,3 @@
+export { default as ColumnManager, ColumnManagerProps } from './ColumnManager';
+export { default as ColumnManagerMenu, ColumnManagerMenuProps } from './ColumnManagerMenu';
+export { default as useColumnManager } from './useColumnManager';

--- a/smart-components/lib/ColumnManager/useColumnManager.d.ts
+++ b/smart-components/lib/ColumnManager/useColumnManager.d.ts
@@ -1,0 +1,11 @@
+import { ReactNode } from 'react';
+
+export default function useColumnManager(
+  prefix: string,
+  columnMapping: Record<string, ReactNode>,
+  persist?: boolean,
+  visibleColumnsProp?: string[],
+): {
+  visibleColumns: string[];
+  toggleColumn: (key: string) => void;
+};

--- a/smart-components/lib/SearchAndSort/ConnectedSource/ApolloConnectedSource.d.ts
+++ b/smart-components/lib/SearchAndSort/ConnectedSource/ApolloConnectedSource.d.ts
@@ -1,6 +1,5 @@
-import { ApolloError } from 'apollo-client';
-import { ApolloConnectedSourceProps, ConnectedSource, StripesError } from './ConnectedSource';
 import Logger from '../../../../util/logger';
+import { ApolloConnectedSourceProps, ApolloError, ConnectedSource } from './ConnectedSource';
 
 export default class ApolloConnectedSource implements ConnectedSource {
   constructor(props: ApolloConnectedSourceProps, logger: Logger, resourceName?: string);
@@ -10,6 +9,7 @@ export default class ApolloConnectedSource implements ConnectedSource {
   pending(): boolean;
   loaded(): boolean;
   failure(): ApolloError | null | undefined;
+
   failureMessage(): string;
   fetchMore(increment: number): void;
   successfulMutations(): unknown[];

--- a/smart-components/lib/SearchAndSort/ConnectedSource/ApolloConnectedSource.d.ts
+++ b/smart-components/lib/SearchAndSort/ConnectedSource/ApolloConnectedSource.d.ts
@@ -1,0 +1,16 @@
+import { ApolloError } from 'apollo-client';
+import { ApolloConnectedSourceProps, ConnectedSource, StripesError } from './ConnectedSource';
+import Logger from '../../../../util/logger';
+
+export default class ApolloConnectedSource implements ConnectedSource {
+  constructor(props: ApolloConnectedSourceProps, logger: Logger, resourceName?: string);
+  records(): unknown[];
+  resultCount(): number;
+  totalCount(): number | null | undefined;
+  pending(): boolean;
+  loaded(): boolean;
+  failure(): ApolloError | null | undefined;
+  failureMessage(): string;
+  fetchMore(increment: number): void;
+  successfulMutations(): unknown[];
+}

--- a/smart-components/lib/SearchAndSort/ConnectedSource/ConnectedSource.d.ts
+++ b/smart-components/lib/SearchAndSort/ConnectedSource/ConnectedSource.d.ts
@@ -1,0 +1,121 @@
+import { ApolloError } from 'apollo-client';
+import Logger from '../../../../util/logger';
+import { QueryFunction } from '../makeQueryFunction';
+
+export interface ApolloConnectedSourceProps {
+  apolloResource?: string;
+  apolloRecordsKey: string;
+  queryFunction: QueryFunction;
+  parentData: {
+    // properties directly on parentData
+    loading?: boolean;
+    successfulMutations?: unknown[];
+    error?: ApolloError;
+    fetchMore(params: {
+      variables: {
+        cql: string;
+        offset: number;
+        limit: number;
+      };
+      // record key is `apolloResource`
+      updateQuery: (
+        prev: Record<string, { records: unknown[] }>,
+        params: { fetchMoreResult: unknown },
+      ) => Record<string, { records: unknown[] }>;
+    }): void;
+  } & {
+    // all within resource name (within recordsObj)
+    [resourceName: string]: {
+      totalRecords?: number;
+    } & {
+      // equals apolloRecordsKey
+      [recordsKey: string]: unknown[];
+    };
+  };
+  parentResources: {
+    query: Record<string, unknown>;
+  };
+}
+
+type StripesError = {
+  dataKey?: string;
+  httpStatus?: unknown;
+  message?: string;
+  module?: unknown;
+  resource?: unknown;
+  throwErrors?: unknown;
+};
+
+type StripesResourceType = {
+  resultCount: number;
+  notes?: string | boolean;
+  filters?: string;
+} & {
+  // called recordsObj in code
+  [resourceName: string]: {
+    records?: unknown[];
+    hasLoaded?: boolean;
+    isPending?: boolean;
+    failed?: StripesError;
+    other?: unknown;
+    successfulMutations?: unknown[];
+  };
+};
+type StripesMutatorType = {
+  resultCount: {
+    replace: (count: number) => void;
+  };
+  resultOffset: {
+    replace: (offset: number) => void;
+  };
+  query: {
+    replace: (query: unknown) => void;
+    update: (query: unknown) => void;
+  };
+};
+
+export interface StripesConnectedSourceProps {
+  // key is from resourceName
+  parentResources: StripesResourceType;
+  resources?: StripesResourceType;
+  parentMutator?: StripesMutatorType;
+  mutator?: StripesMutatorType;
+}
+
+export interface ConnectedSource {
+  records(): unknown[];
+
+  /** Number of records retrieved so far */
+  resultCount(): number;
+  /**
+   * Number of records in the result-set, available to be retrieved.
+   *
+   * For {@code StripesConnectedSource}, when there are > 10k results to a search, the `totalRecords`
+   * value comes back as `999999999`, so we use that value to indicate
+   * that the count is, in fact, undefined vs returning null to indicate
+   * that the count has not been calculated.
+   */
+  totalCount(): number | null | undefined;
+
+  /** True only during a request, false before and after */
+  pending(): boolean;
+
+  /** True only after a request, false before and during */
+  loaded(): boolean;
+
+  failure(): ApolloError | StripesError | undefined | null;
+
+  failureMessage(): string;
+
+  fetchMore(increment: number): void;
+
+  successfulMutations(): unknown[];
+}
+
+export type ConnectedSourceProps = ApolloConnectedSourceProps | StripesConnectedSourceProps;
+
+export default function makeConnectedSource(
+  props: ConnectedSourceProps,
+  logger: Logger,
+  resourceName?: string,
+): ConnectedSource | null;

--- a/smart-components/lib/SearchAndSort/ConnectedSource/ConnectedSource.d.ts
+++ b/smart-components/lib/SearchAndSort/ConnectedSource/ConnectedSource.d.ts
@@ -1,6 +1,12 @@
-import { ApolloError } from 'apollo-client';
 import Logger from '../../../../util/logger';
 import { QueryFunction } from '../makeQueryFunction';
+
+type ApolloError = {
+  message: string;
+  graphQLErrors: unknown[];
+  networkError: Error | null;
+  extraInfo: any;
+};
 
 export interface ApolloConnectedSourceProps {
   apolloResource?: string;

--- a/smart-components/lib/SearchAndSort/ConnectedSource/ConnectedSource.d.ts
+++ b/smart-components/lib/SearchAndSort/ConnectedSource/ConnectedSource.d.ts
@@ -52,37 +52,42 @@ type StripesError = {
   throwErrors?: unknown;
 };
 
-type StripesResourceType = {
-  resultCount: number;
-  notes?: string | boolean;
-  filters?: string;
-} & {
-  // called recordsObj in code
-  [resourceName: string]: {
-    records?: unknown[];
-    hasLoaded?: boolean;
-    isPending?: boolean;
-    failed?: StripesError;
-    other?: unknown;
-    successfulMutations?: unknown[];
-  };
-};
-type StripesMutatorType = {
-  resultCount: {
-    replace: (count: number) => void;
-  };
-  resultOffset: {
-    replace: (offset: number) => void;
-  };
-  query: {
-    replace: (query: unknown) => void;
-    update: (query: unknown) => void;
-  };
-};
+type StripesResourceType =
+  | ({
+      resultCount: number;
+      notes?: string | boolean;
+      filters?: string;
+    } & {
+      // called recordsObj in code
+      [resourceName: string]: {
+        records?: unknown[];
+        hasLoaded?: boolean;
+        isPending?: boolean;
+        failed?: StripesError;
+        other?: unknown;
+        successfulMutations?: unknown[];
+      };
+    })
+  | unknown; // these types may not be perfect; putting this to avoid errors
+
+type StripesMutatorType =
+  | {
+      resultCount: {
+        replace: (count: number) => void;
+      };
+      resultOffset: {
+        replace: (offset: number) => void;
+      };
+      query: {
+        replace: (query: unknown) => void;
+        update: (query: unknown) => void;
+      };
+    }
+  | unknown; // these types may not be perfect; putting this to avoid errors
 
 export interface StripesConnectedSourceProps {
   // key is from resourceName
-  parentResources: StripesResourceType;
+  parentResources?: StripesResourceType;
   resources?: StripesResourceType;
   parentMutator?: StripesMutatorType;
   mutator?: StripesMutatorType;

--- a/smart-components/lib/SearchAndSort/ConnectedSource/StripesConnectedSource.d.ts
+++ b/smart-components/lib/SearchAndSort/ConnectedSource/StripesConnectedSource.d.ts
@@ -1,0 +1,18 @@
+import { StripesConnectedSourceProps, ConnectedSource, StripesError } from './ConnectedSource';
+import Logger from '../../../../util/logger';
+
+export default class StripesConnectedSource implements ConnectedSource {
+  constructor(props: StripesConnectedSourceProps, logger: Logger, resourceName?: string);
+  update(props: StripesConnectedSourceProps, resourceName?: string): void;
+  records(): unknown[];
+  resultCount(): number;
+  totalCount(): number | null | undefined;
+  pending(): boolean;
+  loaded(): boolean;
+  failure(): StripesError | null | undefined;
+  failureMessage(): string;
+  fetchMore(increment: number): void;
+  fetchByBrowsePoint(browsePoint: unknown): void;
+  fetchOffset(index: number): void;
+  successfulMutations(): unknown[];
+}

--- a/smart-components/lib/SearchAndSort/ConnectedSource/index.d.ts
+++ b/smart-components/lib/SearchAndSort/ConnectedSource/index.d.ts
@@ -1,0 +1,7 @@
+export {
+  default,
+  ConnectedSource,
+  ConnectedSourceProps,
+  ApolloConnectedSourceProps,
+  StripesConnectedSourceProps,
+} from './ConnectedSource';

--- a/smart-components/lib/SearchAndSort/SearchAndSort.d.ts
+++ b/smart-components/lib/SearchAndSort/SearchAndSort.d.ts
@@ -1,0 +1,252 @@
+import { ChangeEventHandler, Component, ComponentType, EventHandler, ReactNode, Ref } from 'react';
+import {
+  AdvancedSearchProps,
+  FilterGroupsConfig,
+  FilterGroupsProps,
+  FilterGroupsState,
+  MultiColumnListProps,
+} from '../../../components';
+import { DropdownMenuFunction } from '../../../components/lib/Dropdown/Dropdown';
+import { PaneHeaderDefaultProps } from '../../../components/lib/PaneHeader/PaneHeader';
+import { StripesType } from '../../../core';
+import { ColumnManagerProps } from '../ColumnManager';
+import {
+  ConnectedSource,
+  ConnectedSourceProps,
+  StripesConnectedSourceProps,
+} from './ConnectedSource';
+import { NsParamsType } from './nsQueryFunctions';
+
+export type SearchAndSortProps<
+  EditAndViewProps = Record<string, never>,
+  RecordType = Record<string, unknown>,
+  PreMassagedRecordType = RecordType,
+  CustomFilterRenderType = unknown,
+> = ConnectedSourceProps &
+  StripesConnectedSourceProps & {
+    /** Customizes the pane header's action menu */
+    actionMenu?: (
+      props: Parameters<DropdownMenuFunction>[0] & Partial<ColumnManagerProps>,
+    ) => ReactNode;
+    /** Value of advanced search index option. Tells `<SearchAndSort>` which index to set after searching by Advanced Search */
+    advancedSearchIndex?: string;
+    /** Array of options for Advanced Search component. If empty, Advanced Search will not be rendered. */
+    advancedSearchOptions?: AdvancedSearchProps['searchOptions'];
+    /** Custom query builder for Advanced Search */
+    advancedSearchQueryBuilder?: AdvancedSearchProps['queryBuilder'];
+    /** If the `SearchField` should be auto-focused on mount */
+    autofocusSearchField?: boolean;
+    /** Optional string to customize the path which should be used after performing a search */
+    basePath?: string;
+    /** If true, don't show/navigate to record information on selection */
+    browseOnly?: boolean;
+    /** Get a ref to the underlying pane's title */
+    paneTitleRef?: PaneHeaderDefaultProps['paneTitleRef'];
+    /** Additional props for the `<ColumnManager>` */
+    columnManagerProps?: Partial<ColumnManagerProps>;
+    /** The column mapping for the `<MultiColumnList>` */
+    columnMapping: MultiColumnListProps<RecordType, never>['columnMapping'];
+    /** The column widths for the `<MultiColumnList>` */
+    columnWidths: MultiColumnListProps<RecordType, never>['columnWidths'];
+    /** The path to navigate to when the "New" button is clicked */
+    createRecordPath?: string;
+    /** A component that will be rendered in PaneSubHeader instead of default. */
+    customPaneSubText?: ReactNode;
+    /** A component that will be rendered in the PaneSubHeader (after `customPaneSubText`). */
+    customPaneSub?: ReactNode;
+    /** Additional props to pass to the `editRecordComponent` and `viewRecordComponent` */
+    detailProps?: EditAndViewProps;
+    /** Disables filters for the `<FilterGroups>` */
+    disableFilters?: FilterGroupsProps['disableNames'];
+    /** If true, new records cannot be created */
+    disableRecordCreation?: boolean;
+    /** The component used to edit an existing record.  Can accept additional props via `detailProps` (type `EditAndViewProps` from generic) */
+    editRecordComponent?: ComponentType<
+      EditAndViewProps & {
+        stripes: StripesType;
+        id: string;
+        initialValues?: Partial<RecordType>;
+        connectedSource: ConnectedSource;
+        parentResources: ConnectedSourceProps['parentResources'];
+        parentMutator?: StripesConnectedSourceProps['parentMutator'];
+        onSubmit: (newRecord: PreMassagedRecordType) => unknown;
+        onCancel: (e?: Event) => void;
+      }
+    >;
+    /** Extra parameters to remove from the URL after the search is submitted and the user's search is cleared */
+    extraParamsToReset?: Record<string, unknown>;
+    /** Callback for when the user changes a filter in the default `<FilterGroups>`. Requires renderFilters to NOT be provided */
+    filterChangeCallback?: (state: FilterGroupsState) => void;
+    /** Configuration for `<FilterGroups>`. Requires renderFilters to NOT be provided */
+    filterConfig?: FilterGroupsConfig;
+    /** Newly created records are displayed as soon as they are created. Usually that is as soon as the record itself exists, but in some cases it is not until some other operation has completed -- for example, new user records are not ready to be displayed until their permissions have been added. In such situations, this property may be set to the name of the resource which must have completed its operations before the record is ready. */
+    finishedResourceName?: string;
+    /** Customize classes for the underlying `<MultiColumnList>` */
+    getCellClass?: MultiColumnListProps<RecordType, never>['getCellClass'];
+    /** An optional function to return connected helper component implementation */
+    getHelperComponent?: (helperName: string) => ComponentType;
+    /** An optional function which can be used to return helper's resource path dynamically */
+    getHelperResourcePath?: (helperName: string, id: string) => string;
+    /** If the "New" button should be displayed */
+    hasNewButton?: boolean;
+    /** If row-level click handlers should be enabled */
+    hasRowClickHandlers?: boolean;
+    /** If page indices should be hidden */
+    hidePageIndices?: boolean;
+    /** Search index dropdown element ref */
+    indexRef?: Ref<HTMLElement>;
+    /** Initial filter state; also used when resetting to the initial state */
+    initialFilters?: string;
+    /** The number of records to fetch when a new search is executed (including the null search that is run when the module starts). */
+    initialResultCount?: number;
+    /** Reference to search query input element */
+    inputRef?: Ref<HTMLElement>;
+    /** Type of search box */
+    inputType?: 'text' | 'textarea';
+    /** If the count of items should be hidden */
+    isCountHidden?: boolean;
+    /** Take a record create/edit form and turn it into a "proper" record */
+    massageNewRecord?: (record: PreMassagedRecordType) => RecordType;
+    /** If provided, specifies that maximum number of sort-keys that should be remembered for "stable sorting". Defaults to 2 if not specified. */
+    maxSortKeys?: number;
+    /** Initial values to use when creating a new record */
+    newRecordInitialValues?: Partial<RecordType>;
+    /** Permissions required to create a new record */
+    newRecordPerms?: string;
+    /** A message to show before a search has been submitted */
+    notLoadedMessage?: ReactNode;
+    /** Columns which should not be clickable */
+    nonInteractiveHeaders?: MultiColumnListProps<RecordType, never>['nonInteractiveHeaders'];
+    /** Namespace parameters */
+    nsParams?: NsParamsType;
+    /** Machine-readable name of the object being managed, e.g. `user` */
+    objectName: string;
+    /** Callback for when the user selects a different index */
+    onChangeIndex?: ChangeEventHandler;
+    /** Callback for when the new record layer is closed */
+    onCloseNewRecord?: EventHandler<any>;
+    /** Callback for when the component will unmount */
+    onComponentWillUnmount?: (
+      props: SearchAndSortProps<
+        EditAndViewProps,
+        RecordType,
+        PreMassagedRecordType,
+        CustomFilterRenderType
+      >,
+    ) => void;
+    /** Creates a new record */
+    onCreate?: (record: RecordType) => unknown;
+    /** Callback for when the detail record pane is dismissed */
+    onDismissDetail?: () => void;
+    /** Callback for filters changed from the custom `renderFilters` prop */
+    onFilterChange?: (result: CustomFilterRenderType) => void;
+    /** Callback for when all filters are reset/cleared */
+    onResetAll?: () => void;
+    /** Extends search functionality; called before search is performed */
+    onSubmitSearch?: () => void;
+    /** Optional function to override the default action when selecting a row (which displays the full record). May be used, for example, when running one module embedded in another, as when ui-checkin embeds an instance of ui-users to select the user for whom items are being checked out. */
+    // can only guarantee `id` is present
+    onSelectRow?: (
+      e: MouseEvent | KeyboardEvent | null | undefined,
+      record: Partial<RecordType> & { id: string },
+    ) => void;
+    /** Enable or disable the "Next" button */
+    pagingCanGoNext?: boolean;
+    /** Enable or disable the "Previous" button */
+    pagingCanGoPrevious?: boolean;
+    /** Amount to display per page */
+    pageAmount?: MultiColumnListProps<RecordType, never>['pageAmount'];
+    /** Type of paging for the underlying `<MultiColumnList>` */
+    pagingType?: MultiColumnListProps<RecordType, never>['pagingType'];
+    /** Custom path to use for viewing a record detail */
+    path?: string;
+    /** Custom filters to render */
+    renderFilters?: (callback: (result: CustomFilterRenderType) => void) => ReactNode;
+    /** Custom element to render above the filters */
+    renderNavigation?: () => ReactNode;
+    /** The amount of records to load when getting close to the bottom */
+    resultCountIncrement: number;
+    /** Use a custom translation key for the result count message */
+    resultCountMessageKey?: string;
+    /** Custom row formatter */
+    resultRowFormatter?: MultiColumnListProps<RecordType, never>['rowFormatter'];
+    /** Custom logic to highlight a row as selected in the `<MultiColumnList>` */
+    resultRowIsSelected?: MultiColumnListProps<RecordType, never>['isSelected'];
+    /** Sets the `itemToView` prop of the `<MultiColumnList>` */
+    resultsCachedPosition?: MultiColumnListProps<RecordType, never>['itemToView'];
+    /** Custom formatter for the `<MultiColumnList>` */
+    resultsFormatter?: MultiColumnListProps<RecordType, never>['formatter'];
+    /** Sets the MCL key, can be used to force a re-render */
+    resultsKey?: string;
+    /** Custom `onMarkPosition` on the underlying `<MultiColumnList>` */
+    resultsOnMarkPosition?: MultiColumnListProps<RecordType, never>['onMarkPosition'];
+    /** Custom function to request more results */
+    resultsOnNeedMore?: (args: {
+      records: RecordType[];
+      source: ConnectedSource;
+      direction?: unknown;
+      index: number;
+      firstIndex?: unknown;
+      askAmount: number;
+    }) => void;
+    /** Custom `onMarkReset` on the underlying `<MultiColumnList>` */
+    resultsOnResetMarkedPosition?: MultiColumnListProps<RecordType, never>['onMarkReset'];
+    /** Custom `stickyFirstColumn` on the underlying `<MultiColumnList>` */
+    resultsStickyFirstColumn?: MultiColumnListProps<RecordType, never>['stickyFirstColumn'];
+    /** Custom `stickyLastColumn` on the underlying `<MultiColumnList>` */
+    resultsStickyLastColumn?: MultiColumnListProps<RecordType, never>['stickyLastColumn'];
+    /** Custom `virtualize` on the underlying `<MultiColumnList>` */
+    resultsVirtualize?: MultiColumnListProps<RecordType, never>['virtualize'];
+    /** Indexes which the application can search in. Presence of this property causes a dropdown to appear offering a choice of indexes */
+    searchableIndexes?: {
+      label: string;
+      value: string;
+      disabled?: boolean;
+    }[];
+    /** An unselectable placeholder for use with `searchableIndexes` */
+    searchableIndexesPlaceholder?: string;
+    /** Custom label for the search field */
+    searchFieldButtonLabel?: ReactNode;
+    /** The currently selected index (for use with `searchableIndexes`) */
+    selectedIndex?: string;
+    /** If the details should be shown automatically if a search has only one result */
+    showSingleResult?: boolean;
+    /** If provided, specifies the columns that can be sorted */
+    sortableColumns?: string[];
+    /** Enable or disable syncing the URL `query` with the query input value */
+    syncQueryWithUrl?: boolean;
+    /** Results pane title */
+    title?: ReactNode;
+    /** Validates search query before submission. Submission will be prevented if this returns false. */
+    validateSearchOnSubmit?: (searchTerm: string) => boolean;
+    /** The component used to edit an existing record.  Can accept additional props via `detailProps` (type `EditAndViewProps` from generic) */
+    viewRecordComponent?: ComponentType<
+      EditAndViewProps &
+        // gets all our props, too
+        SearchAndSortProps<
+          EditAndViewProps,
+          RecordType,
+          PreMassagedRecordType,
+          CustomFilterRenderType
+        > & {
+          stripes: StripesType;
+          paneWidth: '44%';
+          parentResources: ConnectedSourceProps['parentResources'];
+          connectedSource: ConnectedSource;
+          parentMutator: StripesConnectedSourceProps['parentMutator'];
+          onClose: () => void;
+          onEdit: (e?: Event) => void;
+          editLink: string;
+          onCloseEdit: (e?: Event) => void;
+          tagsToggle: () => void;
+        }
+    >;
+    /** Gets a link to view a record at. Used in lieu of `viewRecordComponent` */
+    viewRecordPathById?: (id: string) => string;
+    /** Permissions required to view a record */
+    viewRecordPerms: string;
+    /** Columns to display */
+    visibleColumns?: MultiColumnListProps<RecordType, never>['visibleColumns'];
+  };
+
+export default class SearchAndSort extends Component<SearchAndSortProps> {}

--- a/smart-components/lib/SearchAndSort/SearchAndSortQuery.d.ts
+++ b/smart-components/lib/SearchAndSort/SearchAndSortQuery.d.ts
@@ -1,0 +1,2 @@
+declare const SearchAndSortQuery: any;
+export default SearchAndSortQuery;

--- a/smart-components/lib/SearchAndSort/advancedSearchQueryToRows.d.ts
+++ b/smart-components/lib/SearchAndSort/advancedSearchQueryToRows.d.ts
@@ -1,0 +1,6 @@
+export default function advancedSearchQueryToRows(queryValue?: string | null): {
+  query: string;
+  bool: string;
+  searchOption: string;
+  match: string;
+}[];

--- a/smart-components/lib/SearchAndSort/buildUrl.d.ts
+++ b/smart-components/lib/SearchAndSort/buildUrl.d.ts
@@ -1,0 +1,7 @@
+import * as H from 'history';
+
+export default function buildUrl(
+  location: H.Location,
+  values: Record<string, unknown>,
+  basePath?: string,
+): string;

--- a/smart-components/lib/SearchAndSort/components/CheckboxFilter/CheckboxFilter.d.ts
+++ b/smart-components/lib/SearchAndSort/components/CheckboxFilter/CheckboxFilter.d.ts
@@ -1,0 +1,12 @@
+import { Component } from 'react';
+
+export interface CheckboxFilterProps<ValueType extends string | number> {
+  dataOptions: { value: ValueType; label: string; readOnly?: boolean; disabled?: boolean }[];
+  name: string;
+  onChange: (args: { name: string; values: ValueType[] }) => void;
+  selectedValues: ValueType[];
+}
+
+export default class CheckboxFilter<
+  ValueType extends string | number = string | number,
+> extends Component<CheckboxFilterProps<ValueType>> {}

--- a/smart-components/lib/SearchAndSort/components/CheckboxFilter/index.d.ts
+++ b/smart-components/lib/SearchAndSort/components/CheckboxFilter/index.d.ts
@@ -1,0 +1,1 @@
+export { default, CheckboxFilterProps } from './CheckboxFilter';

--- a/smart-components/lib/SearchAndSort/components/CollapseFilterPaneButton/CollapseFilterPaneButton.d.ts
+++ b/smart-components/lib/SearchAndSort/components/CollapseFilterPaneButton/CollapseFilterPaneButton.d.ts
@@ -1,0 +1,7 @@
+import { MouseEventHandler } from 'react';
+
+export interface CollapseFilterPaneButtonProps {
+  onClick: MouseEventHandler<HTMLButtonElement>;
+}
+
+export default function CollapseFilterPaneButton(props: CollapseFilterPaneButtonProps): JSX.Element;

--- a/smart-components/lib/SearchAndSort/components/CollapseFilterPaneButton/index.d.ts
+++ b/smart-components/lib/SearchAndSort/components/CollapseFilterPaneButton/index.d.ts
@@ -1,0 +1,1 @@
+export { default, CollapseFilterPaneButtonProps } from './CollapseFilterPaneButton';

--- a/smart-components/lib/SearchAndSort/components/DateRangeFilter/DateRangeFilter.d.ts
+++ b/smart-components/lib/SearchAndSort/components/DateRangeFilter/DateRangeFilter.d.ts
@@ -1,0 +1,18 @@
+import { Ref } from 'react';
+import { PopperPlacement } from '../../../../../components';
+
+export interface DateRangeFilterProps {
+  dateFormat?: string;
+  focusRef?: Ref<HTMLInputElement>;
+  makeFilterString: (startDate: string, endDate: string) => string;
+  name: string;
+  /** string provided is from makeFilterString */
+  onChange: (args: { name: string; values: [string] }) => void;
+  placement?: PopperPlacement;
+  selectedValues: {
+    endDate: string;
+    startDate: string;
+  };
+}
+
+export default function DateRangeFilter(props: DateRangeFilterProps): JSX.Element;

--- a/smart-components/lib/SearchAndSort/components/DateRangeFilter/index.d.ts
+++ b/smart-components/lib/SearchAndSort/components/DateRangeFilter/index.d.ts
@@ -1,0 +1,1 @@
+export { default, DateRangeFilterProps } from './DateRangeFilter';

--- a/smart-components/lib/SearchAndSort/components/ExpandFilterPaneButton/ExpandFilterPaneButton.d.ts
+++ b/smart-components/lib/SearchAndSort/components/ExpandFilterPaneButton/ExpandFilterPaneButton.d.ts
@@ -1,0 +1,8 @@
+import { MouseEventHandler } from 'react';
+
+export interface ExpandFilterPaneButtonProps {
+  onClick: MouseEventHandler<HTMLButtonElement>;
+  filterCount?: number;
+}
+
+export default function ExpandFilterPaneButton(props: ExpandFilterPaneButtonProps): JSX.Element;

--- a/smart-components/lib/SearchAndSort/components/ExpandFilterPaneButton/index.d.ts
+++ b/smart-components/lib/SearchAndSort/components/ExpandFilterPaneButton/index.d.ts
@@ -1,0 +1,1 @@
+export { default, ExpandFilterPaneButtonProps } from './ExpandFilterPaneButton';

--- a/smart-components/lib/SearchAndSort/components/MultiSelectionFilter/MultiSelectionFilter.d.ts
+++ b/smart-components/lib/SearchAndSort/components/MultiSelectionFilter/MultiSelectionFilter.d.ts
@@ -1,0 +1,10 @@
+import { ReactNode } from 'react';
+
+export interface MultiSelectionFilterProps {
+  dataOptions: { label?: ReactNode; value?: ReactNode }[];
+  name: string;
+  onChange: (args: { name: string; values: string[] }) => void;
+  selectedValues?: string[];
+}
+
+export default function MultiSelectionFilter(props: MultiSelectionFilterProps): JSX.Element;

--- a/smart-components/lib/SearchAndSort/components/MultiSelectionFilter/index.d.ts
+++ b/smart-components/lib/SearchAndSort/components/MultiSelectionFilter/index.d.ts
@@ -1,0 +1,1 @@
+export { default, MultiSelectionFilterProps } from './MultiSelectionFilter';

--- a/smart-components/lib/SearchAndSort/components/NoResultsMessage/NoResultsMessage.d.ts
+++ b/smart-components/lib/SearchAndSort/components/NoResultsMessage/NoResultsMessage.d.ts
@@ -1,0 +1,12 @@
+import { ReactNode } from 'react';
+import { ConnectedSource } from '../../ConnectedSource';
+
+export interface NoResultsMessageProps {
+  source: ConnectedSource;
+  searchTerm: string;
+  filterPaneIsVisible: boolean;
+  toggleFilterPane: () => void;
+  notLoadedMessage?: ReactNode;
+}
+
+export default function NoResultsMessage(props: NoResultsMessageProps): JSX.Element;

--- a/smart-components/lib/SearchAndSort/components/NoResultsMessage/index.d.ts
+++ b/smart-components/lib/SearchAndSort/components/NoResultsMessage/index.d.ts
@@ -1,0 +1,4 @@
+export {
+  default,
+  NoResultsMessageProps as SearchAndSortNoResultsMessageProps,
+} from './NoResultsMessage';

--- a/smart-components/lib/SearchAndSort/components/ResetButton/ResetButton.d.ts
+++ b/smart-components/lib/SearchAndSort/components/ResetButton/ResetButton.d.ts
@@ -1,0 +1,12 @@
+import { MouseEventHandler, ReactNode } from 'react';
+import { ButtonProps } from '../../../../../components';
+
+export type ResetButtonProps = Partial<ButtonProps> & {
+  className?: string;
+  disabled?: boolean;
+  id?: string;
+  label?: ReactNode;
+  onClick: MouseEventHandler<HTMLAnchorElement | HTMLButtonElement>;
+};
+
+export default function ResetButton(props: ResetButtonProps): JSX.Element;

--- a/smart-components/lib/SearchAndSort/components/ResetButton/index.d.ts
+++ b/smart-components/lib/SearchAndSort/components/ResetButton/index.d.ts
@@ -1,0 +1,1 @@
+export { default, ResetButtonProps as SearchAndSortResetButtonProps } from './ResetButton';

--- a/smart-components/lib/SearchAndSort/components/SearchButton/SearchButton.d.ts
+++ b/smart-components/lib/SearchAndSort/components/SearchButton/SearchButton.d.ts
@@ -1,0 +1,10 @@
+import { MouseEventHandler } from 'react';
+import { ButtonProps } from '../../../../../components';
+
+export type SearchButtonProps = Partial<ButtonProps> & {
+  badge?: string | number;
+  onClick: MouseEventHandler<HTMLButtonElement>;
+  visible: boolean;
+};
+
+export default function SearchButton(props: SearchButtonProps): JSX.Element;

--- a/smart-components/lib/SearchAndSort/components/SearchButton/index.d.ts
+++ b/smart-components/lib/SearchAndSort/components/SearchButton/index.d.ts
@@ -1,0 +1,1 @@
+export { default, SearchButtonProps as SearchAndSortSearchButtonProps } from './SearchButton';

--- a/smart-components/lib/SearchAndSort/index.d.ts
+++ b/smart-components/lib/SearchAndSort/index.d.ts
@@ -1,0 +1,4 @@
+export { default, SearchAndSortProps } from './SearchAndSort';
+export { default as makeQueryFunction, QueryFunction } from './makeQueryFunction';
+export { default as SearchAndSortQuery } from './SearchAndSortQuery';
+export { default as advancedSearchQueryToRows } from './advancedSearchQueryToRows';

--- a/smart-components/lib/SearchAndSort/makeQueryFunction.d.ts
+++ b/smart-components/lib/SearchAndSort/makeQueryFunction.d.ts
@@ -1,0 +1,52 @@
+import { FilterGroupsConfig } from '../../../components';
+import Logger from '../../../util/logger';
+import { NsParamsType } from './nsQueryFunctions';
+
+/**
+ * Returns a string, or null, which stripes-connect will use to construct a resource query.
+ *
+ * Accepts four params:
+ * @param queryParams An object containing the UI URL's query parameters (as accessed by ?{name}).
+ * @param pathComponents An object containing the UI URL's path components (as accessed by :{name}).
+ * @param resourceData An object containing the component's resources' data (as accessed by %{name}).
+ * @param logger A logger object.
+ */
+export type QueryFunction = (
+  queryParams: Record<string, unknown>,
+  pathComponents: Record<string, unknown>,
+  resourceData: { query: Record<string, unknown> },
+  logger: Logger,
+) => string | null;
+
+/**
+ * Builds a {@link QueryFunction}
+ *
+ * @param findAll CQL query to retrieve all records when there is a sort clause but no CQL query
+ * @param queryTemplate CQL query to interpolate, or function which will return CQL
+ * @param sortMap map from sort keys to CQL fields
+ * @param filterConfig list of filter objects, see {@link FilterGroupsConfig}
+ * @param failOnCondition one of the following:
+ *   - 0 (or false (legacy)): do not fail even if query and filters and empty
+ *   - 1 (or true (legacy)): fail if query is empty, whatever the filter state
+ *   - 2: fail if both query and filters and empty
+ * @param nsParams namespace keys
+ * @param configOrEscape an object containing configuration parameters:
+ *   - escape: whether to escape the query string (default true)
+ *   - rightTrunc: whether to right-truncate the query string (default true)
+ * For backwards compatibility, this parameter may also be a boolean, in which case it is used as the `escape` configuration value.
+ */
+export default function makeQueryFunction(
+  findAll: string,
+  queryTemplate:
+    | string
+    | ((
+        nsQueryParams: Record<string, unknown>,
+        pathComponents: Record<string, unknown>,
+        queryObj: { query: Record<string, unknown> },
+      ) => string),
+  sortMap: Record<string, string>,
+  filterConfig: FilterGroupsConfig,
+  failOnCondition: 0 | 1 | 2 | true | false,
+  nsParams: NsParamsType,
+  configOrEscape: boolean | { escape?: boolean; rightTrunc?: boolean },
+): QueryFunction;

--- a/smart-components/lib/SearchAndSort/nsQueryFunctions.d.ts
+++ b/smart-components/lib/SearchAndSort/nsQueryFunctions.d.ts
@@ -1,0 +1,32 @@
+export type NsParamsType = string | Record<string, unknown> | undefined | null;
+
+export function getNsKey(key: string, params?: NsParamsType): string;
+
+/**
+ *
+ * Adds namespace / prefix to keys in whitelist for given values object
+ *
+ * @example
+ * ```
+ * values = mapNsKeys({ query: "test", filters: 'active', userId: 1 }, 'users')
+ * // result: { "users.query" : "test", "users.filters": "active", userId: 1 }
+ * ```
+ */
+export function mapNsKeys(
+  values: Record<string, unknown>,
+  params?: NsParamsType,
+): Record<string, unknown>;
+
+/**
+ * Removes namespace / prefix from keys for given values object
+ *
+ * @example
+ * ```
+ * values = removeNsKeys({ "users.query" : "test", "users.filters": "active" }, 'users')
+ * // result: { query: "test", filters: 'active' }
+ * ```
+ */
+export function removeNsKeys(
+  values: Record<string, unknown>,
+  params?: NsParamsType,
+): Record<string, unknown>;

--- a/smart-components/lib/SearchAndSort/parseFilters.d.ts
+++ b/smart-components/lib/SearchAndSort/parseFilters.d.ts
@@ -1,0 +1,2 @@
+export function parseFilters(filters: string): Record<string, string>;
+export function deparseFilters(byName: Record<string, string>): string;

--- a/smart-components/lib/Settings/Settings.d.ts
+++ b/smart-components/lib/Settings/Settings.d.ts
@@ -1,6 +1,5 @@
-import { ReactNode, ComponentType, RefObject, Component } from 'react';
+import { Component, ComponentType, ReactNode, Ref } from 'react';
 import { PaneProps } from '../../../components';
-import { StripesType } from '../../../core';
 
 export interface SettingsProps {
   additionalRoutes?: ReactNode[];
@@ -12,7 +11,7 @@ export interface SettingsProps {
     perm?: string;
   }[];
   paneTitle?: ReactNode;
-  paneTitleRef?: RefObject<HTMLDivElement>;
+  paneTitleRef?: Ref<HTMLDivElement>;
   location: Location;
   showSettings?: boolean;
   forceRender: number;

--- a/util/logger.d.ts
+++ b/util/logger.d.ts
@@ -1,0 +1,3 @@
+// TODO: actual typings for stripes logger
+declare type Logger = (...args: any) => void;
+export default Logger;


### PR DESCRIPTION
# [Jira STTYPES-6](https://issues.folio.org/browse/STTYPES-6)
# [Jira UILISTS-92](https://issues.folio.org/browse/UILISTS-92)

This PR adds typings for `SearchAndSort`, associated components (filters, buttons, etc), and `ColumnManager`.

Per discussion with @zburke and @JohnC-80 the connect-related typings may not be perfect, but we're discouraging its use in new code, so we're OK with this level of detail.

## This must be merged after https://github.com/folio-org/ui-lists/pull/92

## ✨ Bonus ✨ 
PRs made to fix documentation issues in other ilbraries

- https://github.com/folio-org/stripes-smart-components/pull/1427
- https://github.com/folio-org/stripes-smart-components/pull/1428
- https://github.com/folio-org/stripes-components/pull/2207