### PR TITLE
STTYPES-11 bump type-fest to ^4.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2.1.0 in progress
 
 * [STRIPES-893] align stripes-components LayoutGrid to avoid `react-flexbox-grid`
+* [STTYPES-11] bump `type-fest` to `>= 4.12.0` for typescript v5.4 compatibility
 
 ## [2.0.0](https://github.com/folio-org/stripes-types/tree/v2.0.0) (2023-10-11)
 

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "ky": "^0.33.3",
     "moment": "^2.29.4",
     "popper.js": "^1.16.1",
-    "type-fest": "^3.9.0"
+    "type-fest": "^4.12.0"
   },
   "devDependencies": {
     "@folio/eslint-config-stripes": "^7.0.0",


### PR DESCRIPTION
Bump `type-fest` to `^4.12.0` for typescript v5.4 compatibility, avoiding https://github.com/sindresorhus/type-fest/issues/784

Refs [STTYPES-11](https://folio-org.atlassian.net/browse/STTYPES-11)