### PR TITLE
STTYPES-12 build on "tag" events

### DIFF
--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -7,7 +7,8 @@ on:
 jobs:
   ui:
     uses: folio-org/.github/.github/workflows/ui.yml@v1
-    if: github.ref_name == github.event.repository.default_branch || github.event_name != 'push'
+    if: github.ref_name == github.event.repository.default_branch || github.event_name != 'push' || github.ref_type == 'tag'
+
     secrets: inherit
     with:
       # tsc instead of jest, but easiest to run it in the same manner

--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -7,8 +7,8 @@ on:
 jobs:
   ui:
     uses: folio-org/.github/.github/workflows/ui.yml@v1
+    # Only handle push events from the main branch or tags, to decrease PR noise
     if: github.ref_name == github.event.repository.default_branch || github.event_name != 'push' || github.ref_type == 'tag'
-
     secrets: inherit
     with:
       # tsc instead of jest, but easiest to run it in the same manner


### PR DESCRIPTION
Releases are handled by pushing a tag, but the previous action only built on PR events. Whoops!

Refs [STTYPES-12](https://folio-org.atlassian.net/browse/STTYPES-12)