### PR TITLE
STTYPES-13 Fix `useOkapiKy`'s options typing

### DIFF
--- a/core/src/useOkapiKy.d.ts
+++ b/core/src/useOkapiKy.d.ts
@@ -4,4 +4,4 @@ export interface useOkapiKyOptions {
   tenant?: string;
 }
 
-export default function useOkapiKy(options: useOkapiKyOptions): typeof ky;
+export default function useOkapiKy(options?: useOkapiKyOptions): typeof ky;


### PR DESCRIPTION
Make `options` argument for `useOkapiKy` optional.