### PR TITLE
STTYPES-15 Provide TS definitions for claiming feature in the `stripes-acq-components` lib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## 2.3.0 in progress
 
-[[STTYPES-13](https://folio-org.atlassian.net/browse/STTYPES-13)] Add actual types for `acq-components`, `components`, `core` and `smart-components`.
+[STTYPES-13](https://folio-org.atlassian.net/browse/STTYPES-13) Add actual types for `acq-components`, `components`, `core` and `smart-components`.
+[STTYPES-15](https://folio-org.atlassian.net/browse/STTYPES-15) Provide TS definitions for claiming feature in the `stripes-acq-components` library.
 
 ## [2.2.0](https://github.com/folio-org/stripes-types/tree/v2.2.0) (2024-10-11)
 

--- a/acq-components/lib/FindRecords/hooks/useRecordsSelect/useRecordsSelect.d.ts
+++ b/acq-components/lib/FindRecords/hooks/useRecordsSelect/useRecordsSelect.d.ts
@@ -1,1 +1,10 @@
-export const useRecordsSelect: any;
+interface useRecordsSelectReturn<T> {
+  allRecordsSelected: boolean;
+  selectedRecordsMap: Record<string, T>;
+  selectedRecordsLength: number;
+  toggleSelectAll: () => void;
+  selectRecord: (record: T) => void;
+  isRecordSelected: ({ item: T });
+}
+
+export declare function useRecordsSelect<T = unknown & { id: string }>({ records }: { records: T[] }): useRecordsSelectReturn<T>;

--- a/acq-components/lib/FindRecords/hooks/useRecordsSelect/useRecordsSelect.d.ts
+++ b/acq-components/lib/FindRecords/hooks/useRecordsSelect/useRecordsSelect.d.ts
@@ -1,10 +1,11 @@
 interface useRecordsSelectReturn<T> {
   allRecordsSelected: boolean;
-  selectedRecordsMap: Record<string, T>;
-  selectedRecordsLength: number;
-  toggleSelectAll: () => void;
-  selectRecord: (record: T) => void;
   isRecordSelected: ({ item: T });
+  resetSelectedRecords: () => void;
+  selectedRecordsLength: number;
+  selectedRecordsMap: Record<string, T>;
+  selectRecord: (record: T) => void;
+  toggleSelectAll: () => void;
 }
 
 export declare function useRecordsSelect<T = unknown & { id: string }>({ records }: { records: T[] }): useRecordsSelectReturn<T>;

--- a/acq-components/lib/FindRecords/hooks/useRecordsSelect/useRecordsSelect.d.ts
+++ b/acq-components/lib/FindRecords/hooks/useRecordsSelect/useRecordsSelect.d.ts
@@ -1,7 +1,15 @@
 interface useRecordsSelectReturn<T> {
   allRecordsSelected: boolean;
   isRecordSelected: ({ item: T });
-  resetSelectedRecords: () => void;
+  resetAllSelectedRecords: () => void;
+  /*
+   * Clear selected records with provided ids.
+   */
+  resetSelectedRecordsByIds: (ids: string[]) => void;
+  /*
+   * Clear selected records except the ones with provided ids.
+   */
+  resetOtherSelectedRecordsByIds: (ids: string[]) => void;
   selectedRecordsLength: number;
   selectedRecordsMap: Record<string, T>;
   selectRecord: (record: T) => void;

--- a/acq-components/lib/FindRecords/index.d.ts
+++ b/acq-components/lib/FindRecords/index.d.ts
@@ -1,1 +1,2 @@
 export * from './FindRecords';
+export { useRecordsSelect } from './hooks';

--- a/acq-components/lib/claiming/components/index.d.ts
+++ b/acq-components/lib/claiming/components/index.d.ts
@@ -1,0 +1,1 @@
+export * from './menu-items';

--- a/acq-components/lib/claiming/components/index.d.ts
+++ b/acq-components/lib/claiming/components/index.d.ts
@@ -1,1 +1,2 @@
 export * from './menu-items';
+export * from './modals';

--- a/acq-components/lib/claiming/components/menu-items/DelayClaimActionMenuItem/DelayClaimActionMenuItem.d.ts
+++ b/acq-components/lib/claiming/components/menu-items/DelayClaimActionMenuItem/DelayClaimActionMenuItem.d.ts
@@ -1,0 +1,6 @@
+interface DelayClaimActionMenuItemProps {
+  disabled?: boolean;
+  onClick: (e?: Event) => void;
+}
+
+export declare function DelayClaimActionMenuItem(props: DelayClaimActionMenuItemProps): any;

--- a/acq-components/lib/claiming/components/menu-items/DelayClaimActionMenuItem/DelayClaimActionMenuItem.d.ts
+++ b/acq-components/lib/claiming/components/menu-items/DelayClaimActionMenuItem/DelayClaimActionMenuItem.d.ts
@@ -3,4 +3,4 @@ interface DelayClaimActionMenuItemProps {
   onClick: (e?: Event) => void;
 }
 
-export declare function DelayClaimActionMenuItem(props: DelayClaimActionMenuItemProps): any;
+export declare function DelayClaimActionMenuItem(props: DelayClaimActionMenuItemProps): React.JSX.Element;

--- a/acq-components/lib/claiming/components/menu-items/DelayClaimActionMenuItem/index.d.ts
+++ b/acq-components/lib/claiming/components/menu-items/DelayClaimActionMenuItem/index.d.ts
@@ -1,0 +1,1 @@
+export { DelayClaimActionMenuItem } from './DelayClaimActionMenuItem';

--- a/acq-components/lib/claiming/components/menu-items/MarkUnreceivableActionMenuItem/MarkUnreceivableActionMenuItem.d.ts
+++ b/acq-components/lib/claiming/components/menu-items/MarkUnreceivableActionMenuItem/MarkUnreceivableActionMenuItem.d.ts
@@ -1,0 +1,6 @@
+interface MarkUnreceivableActionMenuItemProps {
+  disabled?: boolean;
+  onClick: (e?: Event) => void;
+}
+
+export declare function MarkUnreceivableActionMenuItem(props: MarkUnreceivableActionMenuItemProps): any;

--- a/acq-components/lib/claiming/components/menu-items/MarkUnreceivableActionMenuItem/MarkUnreceivableActionMenuItem.d.ts
+++ b/acq-components/lib/claiming/components/menu-items/MarkUnreceivableActionMenuItem/MarkUnreceivableActionMenuItem.d.ts
@@ -3,4 +3,4 @@ interface MarkUnreceivableActionMenuItemProps {
   onClick: (e?: Event) => void;
 }
 
-export declare function MarkUnreceivableActionMenuItem(props: MarkUnreceivableActionMenuItemProps): any;
+export declare function MarkUnreceivableActionMenuItem(props: MarkUnreceivableActionMenuItemProps): React.JSX.Element;

--- a/acq-components/lib/claiming/components/menu-items/MarkUnreceivableActionMenuItem/index.d.ts
+++ b/acq-components/lib/claiming/components/menu-items/MarkUnreceivableActionMenuItem/index.d.ts
@@ -1,0 +1,1 @@
+export { MarkUnreceivableActionMenuItem } from './MarkUnreceivableActionMenuItem';

--- a/acq-components/lib/claiming/components/menu-items/SendClaimActionMenuItem/SendClaimActionMenuItem.d.ts
+++ b/acq-components/lib/claiming/components/menu-items/SendClaimActionMenuItem/SendClaimActionMenuItem.d.ts
@@ -3,4 +3,4 @@ interface SendClaimActionMenuItemProps {
   onClick: (e?: Event) => void;
 }
 
-export declare function SendClaimActionMenuItem(props: SendClaimActionMenuItemProps): any;
+export declare function SendClaimActionMenuItem(props: SendClaimActionMenuItemProps): React.JSX.Element;

--- a/acq-components/lib/claiming/components/menu-items/SendClaimActionMenuItem/SendClaimActionMenuItem.d.ts
+++ b/acq-components/lib/claiming/components/menu-items/SendClaimActionMenuItem/SendClaimActionMenuItem.d.ts
@@ -1,0 +1,6 @@
+interface SendClaimActionMenuItemProps {
+  disabled?: boolean;
+  onClick: (e?: Event) => void;
+}
+
+export declare function SendClaimActionMenuItem(props: SendClaimActionMenuItemProps): any;

--- a/acq-components/lib/claiming/components/menu-items/SendClaimActionMenuItem/index.d.ts
+++ b/acq-components/lib/claiming/components/menu-items/SendClaimActionMenuItem/index.d.ts
@@ -1,0 +1,1 @@
+export { SendClaimActionMenuItem } from './SendClaimActionMenuItem';

--- a/acq-components/lib/claiming/components/menu-items/index.d.ts
+++ b/acq-components/lib/claiming/components/menu-items/index.d.ts
@@ -1,0 +1,3 @@
+export { DelayClaimActionMenuItem } from './DelayClaimActionMenuItem';
+export { MarkUnreceivableActionMenuItem } from './MarkUnreceivableActionMenuItem';
+export { SendClaimActionMenuItem } from './SendClaimActionMenuItem';

--- a/acq-components/lib/claiming/components/modals/DelayClaimsModal/DelayClaimsModal.d.ts
+++ b/acq-components/lib/claiming/components/modals/DelayClaimsModal/DelayClaimsModal.d.ts
@@ -1,0 +1,20 @@
+import React from 'react';
+import {
+  FormProps,
+  FormRenderProps,
+} from 'react-final-form';
+
+
+interface DelayClaimsModalOwnProps {
+  claimsCount: number;
+  disabled: boolean;
+  onCancel: () => void;
+  open: boolean;
+}
+
+type DelayClaimsModalProps<FormValues = Record<string, unknown>> =
+  DelayClaimsModalOwnProps &
+  Pick<FormProps<FormValues>, 'onSubmit'> &
+  Partial<FormRenderProps<FormValues>>;
+
+export declare const DelayClaimsModal: <FormValues = Record<string, unknown>>(props: DelayClaimsModalProps<FormValues>) => React.JSX.Element;

--- a/acq-components/lib/claiming/components/modals/DelayClaimsModal/DelayClaimsModal.d.ts
+++ b/acq-components/lib/claiming/components/modals/DelayClaimsModal/DelayClaimsModal.d.ts
@@ -8,6 +8,7 @@ import {
 interface DelayClaimsModalOwnProps {
   claimsCount: number;
   disabled: boolean;
+  message?: React.JSX.Element,
   onCancel: () => void;
   open: boolean;
 }

--- a/acq-components/lib/claiming/components/modals/DelayClaimsModal/DelayClaimsModal.d.ts
+++ b/acq-components/lib/claiming/components/modals/DelayClaimsModal/DelayClaimsModal.d.ts
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
   FormProps,
   FormRenderProps,

--- a/acq-components/lib/claiming/components/modals/DelayClaimsModal/index.d.ts
+++ b/acq-components/lib/claiming/components/modals/DelayClaimsModal/index.d.ts
@@ -1,0 +1,1 @@
+export { DelayClaimsModal } from './DelayClaimsModal';

--- a/acq-components/lib/claiming/components/modals/SendClaimsModal/SendClaimsModal.d.ts
+++ b/acq-components/lib/claiming/components/modals/SendClaimsModal/SendClaimsModal.d.ts
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
   FormProps,
   FormRenderProps,

--- a/acq-components/lib/claiming/components/modals/SendClaimsModal/SendClaimsModal.d.ts
+++ b/acq-components/lib/claiming/components/modals/SendClaimsModal/SendClaimsModal.d.ts
@@ -1,0 +1,19 @@
+import React from 'react';
+import {
+  FormProps,
+  FormRenderProps,
+} from 'react-final-form';
+
+interface SendClaimsModalOwnProps {
+  claimsCount: number;
+  disabled: boolean;
+  onCancel: () => void;
+  open: boolean;
+}
+
+type SendClaimsModalProps<FormValues = Record<string, unknown>> =
+  SendClaimsModalOwnProps &
+  Pick<FormProps<FormValues>, 'onSubmit'> &
+  Partial<FormRenderProps<FormValues>>;
+
+export declare const SendClaimsModal: <FormValues = Record<string, unknown>>(props: SendClaimsModalProps<FormValues>) => React.JSX.Element;

--- a/acq-components/lib/claiming/components/modals/SendClaimsModal/SendClaimsModal.d.ts
+++ b/acq-components/lib/claiming/components/modals/SendClaimsModal/SendClaimsModal.d.ts
@@ -7,6 +7,7 @@ import {
 interface SendClaimsModalOwnProps {
   claimsCount: number;
   disabled: boolean;
+  message?: React.JSX.Element,
   onCancel: () => void;
   open: boolean;
 }

--- a/acq-components/lib/claiming/components/modals/SendClaimsModal/index.d.ts
+++ b/acq-components/lib/claiming/components/modals/SendClaimsModal/index.d.ts
@@ -1,0 +1,1 @@
+export { SendClaimsModal } from './SendClaimsModal';

--- a/acq-components/lib/claiming/components/modals/index.d.ts
+++ b/acq-components/lib/claiming/components/modals/index.d.ts
@@ -1,0 +1,2 @@
+export { DelayClaimsModal } from './DelayClaimsModal';
+export { SendClaimsModal } from './SendClaimsModal';

--- a/acq-components/lib/claiming/hooks/index.d.ts
+++ b/acq-components/lib/claiming/hooks/index.d.ts
@@ -1,0 +1,1 @@
+export { useClaimsSend } from './useClaimsSend';

--- a/acq-components/lib/claiming/hooks/index.d.ts
+++ b/acq-components/lib/claiming/hooks/index.d.ts
@@ -1,1 +1,2 @@
-export { useClaimsSend } from './useClaimsSend';
+export { useClaimsDelay } from './useClaimsDelay';
+export { ClaimingPieceResult, useClaimsSend } from './useClaimsSend';

--- a/acq-components/lib/claiming/hooks/useClaimsDelay/index.d.ts
+++ b/acq-components/lib/claiming/hooks/useClaimsDelay/index.d.ts
@@ -1,0 +1,1 @@
+export { useClaimsDelay } from './useClaimsDelay';

--- a/acq-components/lib/claiming/hooks/useClaimsDelay/useClaimsDelay.d.ts
+++ b/acq-components/lib/claiming/hooks/useClaimsDelay/useClaimsDelay.d.ts
@@ -1,0 +1,14 @@
+import { usePiecesStatusBatchUpdate } from '../../../hooks';
+
+interface useClaimsDelayReturn {
+  isLoading: boolean;
+  delayClaims: ({
+    claimingInterval,
+    pieceIds,
+  }: {
+    claimingInterval: number,
+    pieceIds: string[],
+  }) => Promise<ReturnType<typeof usePiecesStatusBatchUpdate>>;
+}
+
+export declare function useClaimsDelay(): useClaimsDelayReturn;

--- a/acq-components/lib/claiming/hooks/useClaimsSend/index.d.ts
+++ b/acq-components/lib/claiming/hooks/useClaimsSend/index.d.ts
@@ -1,0 +1,1 @@
+export { useClaimsSend } from './useClaimsSend';

--- a/acq-components/lib/claiming/hooks/useClaimsSend/index.d.ts
+++ b/acq-components/lib/claiming/hooks/useClaimsSend/index.d.ts
@@ -1,1 +1,1 @@
-export { useClaimsSend } from './useClaimsSend';
+export { ClaimingPieceResult, useClaimsSend } from './useClaimsSend';

--- a/acq-components/lib/claiming/hooks/useClaimsSend/useClaimsSend.d.ts
+++ b/acq-components/lib/claiming/hooks/useClaimsSend/useClaimsSend.d.ts
@@ -1,0 +1,25 @@
+interface SendClaimsData {
+  claimingPieceIds: string[];
+}
+
+export interface ClaimingResult {
+  pieceId: string;
+  type: 'success' | 'failure';
+  error?: {
+    code?: string;
+    message: string;
+    type?: string;
+  };
+}
+
+export interface SendClaimsResponse {
+  claimingPieceResults: ClaimingResult[];
+  totalRecords: number;
+}
+
+interface useClaimsSendReturn {
+  isLoading: boolean;
+  sendClaims: ({ data }: { data: SendClaimsData }) => Promise<SendClaimsResponse>;
+}
+
+export declare function useClaimsSend(): useClaimsSendReturn;

--- a/acq-components/lib/claiming/hooks/useClaimsSend/useClaimsSend.d.ts
+++ b/acq-components/lib/claiming/hooks/useClaimsSend/useClaimsSend.d.ts
@@ -1,8 +1,11 @@
 interface SendClaimsData {
   claimingPieceIds: string[];
+  claimingInterval: number;
+  internalNote?: string;
+  externalNote?: string;
 }
 
-export interface ClaimingResult {
+export interface ClaimingPieceResult {
   pieceId: string;
   type: 'success' | 'failure';
   error?: {
@@ -13,7 +16,7 @@ export interface ClaimingResult {
 }
 
 export interface SendClaimsResponse {
-  claimingPieceResults: ClaimingResult[];
+  claimingPieceResults: ClaimingPieceResult[];
   totalRecords: number;
 }
 

--- a/acq-components/lib/claiming/index.d.ts
+++ b/acq-components/lib/claiming/index.d.ts
@@ -1,2 +1,3 @@
 export * from './components';
 export * from './hooks';
+export * from './utils';

--- a/acq-components/lib/claiming/index.d.ts
+++ b/acq-components/lib/claiming/index.d.ts
@@ -1,0 +1,2 @@
+export * from './components';
+export * from './hooks';

--- a/acq-components/lib/claiming/utils/getClaimingIntervalFromDate.d.ts
+++ b/acq-components/lib/claiming/utils/getClaimingIntervalFromDate.d.ts
@@ -1,0 +1,3 @@
+import dayjs from 'dayjs';
+
+export declare function getClaimingIntervalFromDate(date: dayjs.ConfigType): number;

--- a/acq-components/lib/claiming/utils/index.d.ts
+++ b/acq-components/lib/claiming/utils/index.d.ts
@@ -1,0 +1,1 @@
+export { getClaimingIntervalFromDate } from './getClaimingIntervalFromDate';

--- a/acq-components/lib/hooks/index.d.ts
+++ b/acq-components/lib/hooks/index.d.ts
@@ -15,6 +15,7 @@ export * from './useLocations';
 export * from './useModalToggle';
 export * from './useOrganization';
 export * from './usePaneFocus';
+export * from './usePiecesStatusBatchUpdate';
 export * from './useShowCallout';
 export * from './useToggle';
 export * from './useTranslatedCategories';

--- a/acq-components/lib/hooks/usePiecesStatusBatchUpdate/index.d.ts
+++ b/acq-components/lib/hooks/usePiecesStatusBatchUpdate/index.d.ts
@@ -1,0 +1,1 @@
+export { usePiecesStatusBatchUpdate } from './usePiecesStatusBatchUpdate';

--- a/acq-components/lib/hooks/usePiecesStatusBatchUpdate/usePiecesStatusBatchUpdate.d.ts
+++ b/acq-components/lib/hooks/usePiecesStatusBatchUpdate/usePiecesStatusBatchUpdate.d.ts
@@ -1,0 +1,21 @@
+export interface UpdatePiecesStatusData {
+  pieceIds: string[],
+  receivingStatus: ACQ.Piece.ReceivingStatus,
+  claimingInterval?: number,
+}
+
+interface UpdatePiecesStatusErrorResponse {
+  errors: Array<{
+    message: string;
+    code?: string;
+  }>
+}
+
+export type UpdatePiecesStatusResponse = null | UpdatePiecesStatusErrorResponse;
+
+interface usePiecesStatusBatchUpdateReturn {
+  isLoading: boolean;
+  updatePiecesStatus: ({ data }: { data: UpdatePiecesStatusData }) => Promise<UpdatePiecesStatusResponse>;
+}
+
+export declare function usePiecesStatusBatchUpdate(): usePiecesStatusBatchUpdateReturn;

--- a/acq-components/lib/hooks/useShowCallout/useShowCallout.d.ts
+++ b/acq-components/lib/hooks/useShowCallout/useShowCallout.d.ts
@@ -1,1 +1,10 @@
-export const useShowCallout: any;
+import { CalloutContextType } from '../../../../core';
+
+type ShowCalloutFnArgs = Omit<Parameters<CalloutContextType['sendCallout']>[0], 'message'> & {
+  message?: string,
+  messageId?: string,
+};
+
+type ShowCalloutFn = (args: ShowCalloutFnArgs) => void;
+
+export declare function useShowCallout(): ShowCalloutFn;

--- a/acq-components/lib/hooks/useShowCallout/useShowCallout.d.ts
+++ b/acq-components/lib/hooks/useShowCallout/useShowCallout.d.ts
@@ -1,8 +1,9 @@
 import { CalloutContextType } from '../../../../core';
 
 type ShowCalloutFnArgs = Omit<Parameters<CalloutContextType['sendCallout']>[0], 'message'> & {
-  message?: string,
+  message?: string | React.ReactNode,
   messageId?: string,
+  values?: Record<string, string>,
 };
 
 type ShowCalloutFn = (args: ShowCalloutFnArgs) => void;

--- a/acq-components/lib/index.d.ts
+++ b/acq-components/lib/index.d.ts
@@ -9,6 +9,7 @@ export * from './AcqUnits';
 export * from './AmountWithCurrencyField';
 export * from './apiHooks';
 export * from './BooleanFilter';
+export * from './claiming';
 export * from './constants';
 export * from './ContributorDetails';
 export * from './CountryFilter';

--- a/acq-components/lib/utils/errorHandling/ResponseErrorsContainer.d.ts
+++ b/acq-components/lib/utils/errorHandling/ResponseErrorsContainer.d.ts
@@ -7,7 +7,7 @@ export interface ResponseErrorsContainerBody {
 }
 
 export interface ErrorHandlingStrategy {
-  handle(errors: ResponseErrorsContainer): void;
+  handle(errors: ResponseErrorsContainer): void | Promise<void>;
 }
 
 /**

--- a/acq-components/lib/utils/errorHandling/index.d.ts
+++ b/acq-components/lib/utils/errorHandling/index.d.ts
@@ -1,1 +1,4 @@
-export { ResponseErrorsContainer } from './ResponseErrorsContainer';
+export {
+  ErrorHandlingStrategy,
+  ResponseErrorsContainer,
+} from './ResponseErrorsContainer';

--- a/final-form/index.d.ts
+++ b/final-form/index.d.ts
@@ -1,2 +1,2 @@
 // targeted to stripes-final-form v7.0.0
-export { default } from './lib/stripesFinalForm';
+export { default, FormProps, FormRenderProps } from './lib/stripesFinalForm';

--- a/final-form/lib/stripesFinalForm.d.ts
+++ b/final-form/lib/stripesFinalForm.d.ts
@@ -29,3 +29,5 @@ export default function stripesFinalForm<
 ): (
   Component: ComponentType<FormRenderProps<FormValues> & ComponentProps>
 ) => ComponentType<ComponentProps & Pick<FormProps<FormValues>, extractedProps>>;
+
+export type { FormProps, FormRenderProps } from 'react-final-form';


### PR DESCRIPTION
## Purpose
https://folio-org.atlassian.net/browse/STTYPES-15

Ref: https://github.com/folio-org/stripes-acq-components/pull/841

Adding TypeScript typings for new claiming ACQ components:  
- `<SendClaimActionMenuItem>`  
- `<SendClaimsModal>`  
- `<DelayClaimActionMenuItem>`  
- `<DelayClaimsModal>`  
- `<MarkUnreceivableActionMenuItem>`  
- `getClaimingIntervalFromDate`  
- `useClaimsDelay`  
- `useClaimsSend`  
- `usePiecesStatusBatchUpdate`  

Adding TypeScript typings for existing ACQ components:  
- `useRecordsSelect`  
- `useShowCallout`  

Re-exporting `react-final-form` interfaces from `stripes-final-form`.