### PR TITLE
STTYPES-19 upgrade react-intl to v7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 3.0.0 IN PROGRESS
 
 * [[STTYPES-18](https://folio-org.atlassian.net/browse/STTYPES-18)] Upgrade `@folio/stripes-*` dependencies.
+* [[STTYPES-19](https://folio-org.atlassian.net/browse/STTYPES-19)] Upgrade `react-intl` to `^7.0.0`.
 
 ## [2.3.0](https://github.com/folio-org/stripes-types/tree/v2.3.0) (2025-01-31)
 

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "final-form": "^4.20.9",
     "react": "^18.2.0",
     "react-final-form": "^6.5.9",
-    "react-intl": "^6.4.1",
+    "react-intl": "^7.1.5",
     "react-router-dom": "^5.2.0"
   },
   "peerDependencies": {
@@ -62,7 +62,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-final-form": "^6.5.9",
-    "react-intl": "^6.4.1",
+    "react-intl": "^7.1.5",
     "react-router-dom": "^5.2.0"
   },
   "scripts": {


### PR DESCRIPTION
Upgrade `react-intl` to `v7`.

Refs [STTYPES-19](https://folio-org.atlassian.net/browse/STTYPES-19)