### PR TITLE
STTYPES-21 Update ACQ interfaces to reflect BE changes: `userLimit` type (`number` → `string`) and schema cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-types
 
+## 4.0.0 (IN PROGRESS)
+
+* [[STTYPES-21](https://folio-org.atlassian.net/browse/STTYPES-21)] Update ACQ interfaces reflect BE changes: `userLimit` type (`number` → `string`) and schema cleanup.
+
 ## [3.0.1](https://github.com/folio-org/stripes-types/tree/v3.0.1) (2025-02-24)
 
 * [[STTYPES-20](https://folio-org.atlassian.net/browse/STTYPES-20)] Add missing `Timepicker` props.

--- a/acq-components/definitions/order-line.d.ts
+++ b/acq-components/definitions/order-line.d.ts
@@ -14,8 +14,6 @@ declare namespace ACQ {
     acquisitionMethod: string;
     /** If true then line will be marked as available to export in the EDIFACT format or other format */
     automaticExport?: boolean;
-    /** Alerts associated with this purchase order line */
-    alerts?: OrderLine.Alert[];
     /** Whether or not there are cancellation restrictions for this purchase order line */
     cancellationRestriction?: boolean;
     /** Free-form notes related to cancellation restrictions */
@@ -76,8 +74,6 @@ declare namespace ACQ {
     receiptStatus?: OrderLine.ReceiptStatus;
     /** Renewal note for this purchase order line */
     renewalNote?: string;
-    /** A list of reporting codes associated with this purchase order line */
-    reportingCodes?: OrderLine.ReportingCode[];
     /** Who requested this purchase order line */
     requester?: string;
     /** Whether or not this is a rush order */
@@ -99,13 +95,6 @@ declare namespace ACQ {
   }
 
   namespace OrderLine {
-    interface Alert {
-      /** UUID of this alert record */
-      id?: string;
-      /** The alert text */
-      alert: string;
-    }
-
     /* not-stable: possibly changed in the future */
     interface Claim {
       /** Whether or not this purchase order line has been claimed */
@@ -186,7 +175,7 @@ declare namespace ACQ {
       /** Expected date the resource will be activated */
       expectedActivation?: string;
       /** The concurrent user-limit */
-      userLimit?: number;
+      userLimit?: string;
       /** UUID of the access provider */
       accessProvider?: string;
       /** License record */
@@ -249,15 +238,6 @@ declare namespace ACQ {
       receiptDue?: string | null;
       /** List of volumes included to the physical material */
       volumes: string[];
-    }
-
-    interface ReportingCode {
-      /** UUID of this reporting code record */
-      id?: string;
-      /** A reporting code */
-      code: string;
-      /** Description of this reporting code */
-      description?: string;
     }
 
     interface VendorDetail {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-types",
-  "version": "3.0.1",
+  "version": "4.0.0",
   "description": "Typings for the Stripes framework",
   "license": "Apache-2.0",
   "repository": "folio-org/stripes-types",


### PR DESCRIPTION
JIRA https://folio-org.atlassian.net/browse/STTYPES-21

Changes in BE ([#1108](https://github.com/folio-org/mod-orders/pull/1108/files), [#1104](https://github.com/folio-org/mod-orders/pull/1104/files)):  

- `userLimit` type changed from `number` to string.  
- Deprecated fields removed (e.g., `alerts`, `reportingCodes`).